### PR TITLE
Add self-management (presence, etc.) tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ MCP-Discord provides the following Discord-related functionalities:
 - Create/delete text channels
 - Add/remove message reactions
 - Create/edit/delete/use webhooks
+- Update bot status and presence/activity
 
 ## Table of Contents
 
@@ -34,6 +35,7 @@ MCP-Discord provides the following Discord-related functionalities:
   - [Forum Functions](#forum-functions)
   - [Messages and Reactions](#messages-and-reactions)
   - [Webhook Management](#webhook-management)
+  - [Bot Status and Presence](#bot-status-and-presence)
 - [Development](#development)
 - [License](#license)
 
@@ -302,6 +304,14 @@ You can use Docker containers with both Claude and Cursor:
 - `discord_send_webhook_message`: Sends a message to a Discord channel using a webhook
 - `discord_edit_webhook`: Edits an existing webhook for a Discord channel
 - `discord_delete_webhook`: Deletes an existing webhook for a Discord channel
+
+### Bot Status and Presence
+
+- `discord_set_bot_status`: Sets the bot's online status
+  - Options: `online` (green), `idle` (yellow/away), `dnd` (red/do not disturb), `invisible` (appears offline)
+- `discord_set_bot_activity`: Sets the bot's activity/presence (what the bot is doing)
+  - Activity types: `playing`, `streaming`, `listening`, `watching`, `competing`, `custom`
+  - For `streaming` type, a valid Twitch or YouTube URL can be provided
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -307,11 +307,7 @@ You can use Docker containers with both Claude and Cursor:
 
 ### Bot Status and Presence
 
-- `discord_set_bot_status`: Sets the bot's online status
-  - Options: `online` (green), `idle` (yellow/away), `dnd` (red/do not disturb), `invisible` (appears offline)
-- `discord_set_bot_activity`: Sets the bot's activity/presence (what the bot is doing)
-  - Activity types: `playing`, `streaming`, `listening`, `watching`, `competing`, `custom`
-  - For `streaming` type, a valid Twitch or YouTube URL can be provided
+- `discord_set_presence`: Sets the bot's presence (status) and activity status on Discord
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -307,6 +307,8 @@ You can use Docker containers with both Claude and Cursor:
 
 ### Bot Status and Presence
 
+- `discord_set_bio`: Set or clear the bot's 'Bio' section in a specified server
+- `discord_set_nickname`: Set or clear the bot's nickname in a specified server
 - `discord_set_presence`: Sets the bot's presence (status) and activity status on Discord
 
 ## Development

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.11.0",
-        "discord.js": "^14.19.3",
+        "discord.js": "^14.23.2",
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
         "zod": "^3.25.13"
@@ -42,15 +42,15 @@
       }
     },
     "node_modules/@discordjs/builders": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.11.2.tgz",
-      "integrity": "sha512-F1WTABdd8/R9D1icJzajC4IuLyyS8f3rTOz66JsSI3pKvpCAtsMBweu8cyNYsIyvcrKAVn9EPK+Psoymq+XC0A==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.12.2.tgz",
+      "integrity": "sha512-AugKmrgRJOHXEyMkABH/hXpAmIBKbYokCEl9VAM4Kh6FvkdobQ+Zhv7AR6K+y5hS7+VQ7gKXPYCe1JQmV07H1g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@discordjs/formatters": "^0.6.1",
         "@discordjs/util": "^1.1.1",
         "@sapphire/shapeshift": "^4.0.0",
-        "discord-api-types": "^0.38.1",
+        "discord-api-types": "^0.38.26",
         "fast-deep-equal": "^3.1.3",
         "ts-mixer": "^6.0.4",
         "tslib": "^2.6.3"
@@ -87,9 +87,9 @@
       }
     },
     "node_modules/@discordjs/rest": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.5.0.tgz",
-      "integrity": "sha512-PWhchxTzpn9EV3vvPRpwS0EE2rNYB9pvzDU/eLLW3mByJl0ZHZjHI2/wA8EbH2gRMQV7nu+0FoDF84oiPl8VAQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.0.tgz",
+      "integrity": "sha512-RDYrhmpB7mTvmCKcpj+pc5k7POKszS4E2O9TYc+U+Y4iaCP+r910QdO43qmpOja8LRr1RJ0b3U+CqVsnPqzf4w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@discordjs/collection": "^2.1.1",
@@ -97,10 +97,10 @@
         "@sapphire/async-queue": "^1.5.3",
         "@sapphire/snowflake": "^3.5.3",
         "@vladfrangu/async_event_emitter": "^2.4.6",
-        "discord-api-types": "^0.38.1",
+        "discord-api-types": "^0.38.16",
         "magic-bytes.js": "^1.10.0",
         "tslib": "^2.6.3",
-        "undici": "6.21.1"
+        "undici": "6.21.3"
       },
       "engines": {
         "node": ">=18"
@@ -134,13 +134,13 @@
       }
     },
     "node_modules/@discordjs/ws": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.2.tgz",
-      "integrity": "sha512-dyfq7yn0wO0IYeYOs3z79I6/HumhmKISzFL0Z+007zQJMtAFGtt3AEoq1nuLXtcunUE5YYYQqgKvybXukAK8/w==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.3.tgz",
+      "integrity": "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@discordjs/collection": "^2.1.0",
-        "@discordjs/rest": "^2.5.0",
+        "@discordjs/rest": "^2.5.1",
         "@discordjs/util": "^1.1.0",
         "@sapphire/async-queue": "^1.5.2",
         "@types/ws": "^8.5.10",
@@ -343,6 +343,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.50.tgz",
       "integrity": "sha512-Mxiq0ULv/zo1OzOhwPqOA13I81CV/W3nvd3ChtQZRT5Cwz3cr0FKo/wMSsbTqL3EXpaBAEQhva2B8ByRkOIh9A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -394,9 +395,9 @@
       }
     },
     "node_modules/@vladfrangu/async_event_emitter": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.6.tgz",
-      "integrity": "sha512-RaI5qZo6D2CVS6sTHFKg1v5Ohq/+Bo2LZ5gzUEwZ/WkHhwtGTCB/sVLw8ijOkAUxasZ+WshN/Rzj4ywsABJ5ZA==",
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.7.tgz",
+      "integrity": "sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==",
       "license": "MIT",
       "engines": {
         "node": ">=v14.0.0",
@@ -617,33 +618,33 @@
       }
     },
     "node_modules/discord-api-types": {
-      "version": "0.38.8",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.8.tgz",
-      "integrity": "sha512-xuRXPD44FcbKHrQK15FS1HFlMRNJtsaZou/SVws18vQ7zHqmlxyDktMkZpyvD6gE2ctGOVYC/jUyoMMAyBWfcw==",
+      "version": "0.38.30",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.30.tgz",
+      "integrity": "sha512-KhAqlBrg+rVK+Ob7INMF5o63yW4/GUzRatG/AjyVsIO8lgcLyR8qCl2HokIVzWwmzkJYG0CEPXsKMOqau3E8NA==",
       "license": "MIT",
       "workspaces": [
         "scripts/actions/documentation"
       ]
     },
     "node_modules/discord.js": {
-      "version": "14.19.3",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.19.3.tgz",
-      "integrity": "sha512-lncTRk0k+8Q5D3nThnODBR8fR8x2fM798o8Vsr40Krx0DjPwpZCuxxTcFMrXMQVOqM1QB9wqWgaXPg3TbmlHqA==",
+      "version": "14.23.2",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.23.2.tgz",
+      "integrity": "sha512-tU2NFr823X3TXEc8KyR/4m296KLxPai4nirN3q9kHCpY4TKj96n9lHZnyLzRNMui8EbL07jg9hgH2PWWfKMGIg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@discordjs/builders": "^1.11.2",
+        "@discordjs/builders": "^1.12.1",
         "@discordjs/collection": "1.5.3",
         "@discordjs/formatters": "^0.6.1",
-        "@discordjs/rest": "^2.5.0",
+        "@discordjs/rest": "^2.6.0",
         "@discordjs/util": "^1.1.1",
-        "@discordjs/ws": "^1.2.2",
+        "@discordjs/ws": "^1.2.3",
         "@sapphire/snowflake": "3.5.3",
-        "discord-api-types": "^0.38.1",
+        "discord-api-types": "^0.38.29",
         "fast-deep-equal": "3.1.3",
         "lodash.snakecase": "4.1.1",
         "magic-bytes.js": "^1.10.0",
         "tslib": "^2.6.3",
-        "undici": "6.21.1"
+        "undici": "6.21.3"
       },
       "engines": {
         "node": ">=18"
@@ -764,6 +765,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -1487,6 +1489,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1496,9 +1499,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.21.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.1.tgz",
-      "integrity": "sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==",
+      "version": "6.21.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"
@@ -1557,9 +1560,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.18.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
-      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -1592,6 +1595,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.13.tgz",
       "integrity": "sha512-Q8mvk2iWi7rTDfpQBsu4ziE7A6AxgzJ5hzRyRYQkoV3A3niYsXVwDaP1Kbz3nWav6S+VZ6k2OznFn8ZyDHvIrg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.11.0",
-    "discord.js": "^14.19.3",
+    "discord.js": "^14.23.2",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "zod": "^3.25.13"

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -170,3 +170,18 @@ export const SetPresenceSchema = z.object({
         ).optional()
     }).optional()
 });
+
+export const SetNicknameSchema = z.object({
+    guildId: z.string({
+        description: "The ID of the server where to set the nickname."
+    }),
+    nickname: z.string({
+        description: "The nickname to set for the bot."
+    })
+});
+
+export const SetAboutMeSchema = z.object({
+    aboutMe: z.string({
+        description: "The 'About Me' section content to set."
+    })
+});

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -175,7 +175,7 @@ export const SetNicknameSchema = z.object({
     guildId: z.string({
         description: "The ID of the server where to set the nickname."
     }).min(1, "guildId is required"),
-    nickname: z.string({
+    nick: z.string({
         description: "The nickname to set (leave empty to reset)."
     }).optional()
 });

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -186,3 +186,14 @@ export const SetAboutMeSchema = z.object({
     })
 });
 
+export const SetBioSchema = z.object({
+    guildId: z.string({
+        description: "The ID of the server where to set the bio."
+    }).min(1, "guildId is required"),
+    bio: z.string({
+        description: "The 'Bio' section content to set for the bot in the specified server."
+    }).optional()
+}, {
+    description: "Schema for setting the 'Bio' section in a specific server."
+});
+

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -174,10 +174,10 @@ export const SetPresenceSchema = z.object({
 export const SetNicknameSchema = z.object({
     guildId: z.string({
         description: "The ID of the server where to set the nickname."
-    }),
+    }).min(1, "guildId is required"),
     nickname: z.string({
-        description: "The nickname to set for the bot."
-    })
+        description: "The nickname to set (leave empty to reset)."
+    }).optional()
 });
 
 export const SetAboutMeSchema = z.object({

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -135,19 +135,30 @@ export const DeleteWebhookSchema = z.object({
 export const ListServersSchema = z.object({});
 
 export const SearchMessagesSchema = z.object({
-  guildId: z.string().min(1, "guildId is required"),
-  // Optional filters
-  content: z.string().optional(),
-  authorId: z.string().optional(),
-  mentions: z.string().optional(),
-  has: z.enum(['link','embed','file','poll','image','video','sound','sticker','snapshot']).optional(),
-  maxId: z.string().optional(),
-  minId: z.string().optional(),
-  channelId: z.string().optional(),
-  pinned: z.boolean().optional(),
-  authorType: z.enum(['user','bot','webhook']).optional(),
-  sortBy: z.enum(['timestamp','relevance']).optional(),
-  sortOrder: z.enum(['desc','asc']).optional(),
-  limit: z.number().min(1).max(100).default(25).optional(),
-  offset: z.number().min(0).default(0).optional()
+    guildId: z.string().min(1, "guildId is required"),
+    // Optional filters
+    content: z.string().optional(),
+    authorId: z.string().optional(),
+    mentions: z.string().optional(),
+    has: z.enum(['link', 'embed', 'file', 'poll', 'image', 'video', 'sound', 'sticker', 'snapshot']).optional(),
+    maxId: z.string().optional(),
+    minId: z.string().optional(),
+    channelId: z.string().optional(),
+    pinned: z.boolean().optional(),
+    authorType: z.enum(['user', 'bot', 'webhook']).optional(),
+    sortBy: z.enum(['timestamp', 'relevance']).optional(),
+    sortOrder: z.enum(['desc', 'asc']).optional(),
+    limit: z.number().min(1).max(100).default(25).optional(),
+    offset: z.number().min(0).default(0).optional()
+});
+
+// Bot presence/status schemas
+export const SetBotStatusSchema = z.object({
+    status: z.enum(["online", "idle", "dnd", "invisible"])
+});
+
+export const SetBotActivitySchema = z.object({
+    activityType: z.enum(["playing", "streaming", "listening", "watching", "competing", "custom"]),
+    activityName: z.string(),
+    url: z.string().optional()
 });

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -153,12 +153,20 @@ export const SearchMessagesSchema = z.object({
 });
 
 // Bot presence/status schemas
-export const SetBotStatusSchema = z.object({
-    status: z.enum(["online", "idle", "dnd", "invisible"])
-});
-
-export const SetBotActivitySchema = z.object({
-    activityType: z.enum(["playing", "streaming", "listening", "watching", "competing", "custom"]),
-    activityName: z.string(),
-    url: z.string().optional()
+export const SetPresenceSchema = z.object({
+    status: z.enum(["online", "idle", "dnd", "invisible"], { description: "The presence status to set." }),
+    afk: z.boolean({
+        description: "Whether I am AFK.",
+    }).optional(),
+    activities: z.object({
+        type: z.enum(
+            ["PLAYING", "STREAMING", "LISTENING", "WATCHING", "COMPETING", "CUSTOM"],
+            { description: "The type of activity." }),
+        name: z.string(
+            { description: "The name of the activity." }
+        ),
+        url: z.string(
+            { description: "The URL for the activity (only for STREAMING type)." }
+        ).optional()
+    }).optional()
 });

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -182,6 +182,7 @@ export const SetNicknameSchema = z.object({
 
 export const SetAboutMeSchema = z.object({
     aboutMe: z.string({
-        description: "The 'About Me' section content to set."
+        description: "The global 'About Me' section content."
     })
 });
+

--- a/src/server.ts
+++ b/src/server.ts
@@ -33,6 +33,8 @@ import {
   listServersHandler,
   searchMessagesHandler,
   setPresenceHandler,
+  setNicknameHandler,
+  setBioHandler,
 } from './tools/tools.js';
 import { MCPTransport } from './transport.js';
 import { info, error } from './logger.js';
@@ -43,7 +45,7 @@ export class DiscordMCPServer {
   private clientStatusInterval: NodeJS.Timeout | null = null;
 
   constructor(
-    private client: Client, 
+    private client: Client,
     private transport: MCPTransport
   ) {
     this.server = new Server(
@@ -191,9 +193,19 @@ export class DiscordMCPServer {
             toolResponse = await searchMessagesHandler(args, this.toolContext);
             return toolResponse;
 
-          case "discord_set_bot_presence":
+          case "discord_set_presence":
             this.logClientState("before discord_set_bot_presence handler");
             toolResponse = await setPresenceHandler(args, this.toolContext);
+            return toolResponse;
+
+          case "discord_set_nickname":
+            this.logClientState("before discord_set_nickname handler");
+            toolResponse = await setNicknameHandler(args, this.toolContext);
+            return toolResponse;
+
+          case "discord_set_bio":
+            this.logClientState("before discord_set_bio handler");
+            toolResponse = await setBioHandler(args, this.toolContext);
             return toolResponse;
 
           default:
@@ -236,12 +248,12 @@ export class DiscordMCPServer {
     // Add client to server context so transport can access it
     (this.server as any)._context = { client: this.client };
     (this.server as any).client = this.client;
-    
+
     // Setup periodic client state logging
     this.clientStatusInterval = setInterval(() => {
       this.logClientState("periodic check");
     }, 10000);
-    
+
     await this.transport.start(this.server);
   }
 
@@ -251,7 +263,7 @@ export class DiscordMCPServer {
       clearInterval(this.clientStatusInterval);
       this.clientStatusInterval = null;
     }
-    
+
     await this.transport.stop();
   }
 } 

--- a/src/server.ts
+++ b/src/server.ts
@@ -32,8 +32,7 @@ import {
   deleteCategoryHandler,
   listServersHandler,
   searchMessagesHandler,
-  setBotStatusHandler,
-  setBotActivityHandler
+  setPresenceHandler,
 } from './tools/tools.js';
 import { MCPTransport } from './transport.js';
 import { info, error } from './logger.js';
@@ -192,14 +191,9 @@ export class DiscordMCPServer {
             toolResponse = await searchMessagesHandler(args, this.toolContext);
             return toolResponse;
 
-          case "discord_set_bot_status":
-            this.logClientState("before discord_set_bot_status handler");
-            toolResponse = await setBotStatusHandler(args, this.toolContext);
-            return toolResponse;
-
-          case "discord_set_bot_activity":
-            this.logClientState("before discord_set_bot_activity handler");
-            toolResponse = await setBotActivityHandler(args, this.toolContext);
+          case "discord_set_bot_presence":
+            this.logClientState("before discord_set_bot_presence handler");
+            toolResponse = await setPresenceHandler(args, this.toolContext);
             return toolResponse;
 
           default:

--- a/src/server.ts
+++ b/src/server.ts
@@ -31,7 +31,9 @@ import {
   editCategoryHandler,
   deleteCategoryHandler,
   listServersHandler,
-  searchMessagesHandler
+  searchMessagesHandler,
+  setBotStatusHandler,
+  setBotActivityHandler
 } from './tools/tools.js';
 import { MCPTransport } from './transport.js';
 import { info, error } from './logger.js';
@@ -188,6 +190,16 @@ export class DiscordMCPServer {
           case "discord_search_messages":
             this.logClientState("before discord_search_messages handler");
             toolResponse = await searchMessagesHandler(args, this.toolContext);
+            return toolResponse;
+
+          case "discord_set_bot_status":
+            this.logClientState("before discord_set_bot_status handler");
+            toolResponse = await setBotStatusHandler(args, this.toolContext);
+            return toolResponse;
+
+          case "discord_set_bot_activity":
+            this.logClientState("before discord_set_bot_activity handler");
+            toolResponse = await setBotActivityHandler(args, this.toolContext);
             return toolResponse;
 
           default:

--- a/src/toolList.ts
+++ b/src/toolList.ts
@@ -328,41 +328,58 @@ export const toolList = [
     }
   },
   {
-    name: "discord_set_bot_status",
-    description: "Sets the bot's online status (online, idle, dnd, or invisible)",
+    name: "discord_set_presence",
+    description: "Sets the bot's presence (status and activity) in Discord",
     inputSchema: {
       type: "object",
       properties: {
-        status: {
-          type: "string",
-          enum: ["online", "idle", "dnd", "invisible"],
-          description: "The status to set. Options: online (green), idle (yellow/away), dnd (red/do not disturb), invisible (appears offline)"
+        status: { type: "string", enum: ["online", "idle", "dnd", "invisible"], description: "The presence status to set." },
+        afk: { type: "boolean", description: "Whether the bot is AFK." },
+        activities: {
+          type: "object",
+          properties: {
+            type: { type: "string", enum: ["PLAYING", "STREAMING", "LISTENING", "WATCHING", "COMPETING", "CUSTOM"], description: "The type of activity (e.g. 'Listening to...', 'Playing...')." },
+            name: { type: "string", description: "The name of the activity." },
+            url: { type: "string", description: "The URL for the activity (only for STREAMING type)." }
+          }
         }
       },
       required: ["status"]
     }
   },
   {
-    name: "discord_set_bot_activity",
-    description: "Sets the bot's activity/presence (what the bot is doing)",
+    name: "discord_set_nickname",
+    description: "Sets the bot's nickname in a specified Discord server (guild).",
     inputSchema: {
       type: "object",
       properties: {
-        activityType: {
-          type: "string",
-          enum: ["playing", "streaming", "listening", "watching", "competing", "custom"],
-          description: "The type of activity"
-        },
-        activityName: {
-          type: "string",
-          description: "The name/description of the activity"
-        },
-        url: {
-          type: "string",
-          description: "Optional URL (only used for streaming activity type, must be a valid Twitch or YouTube URL)"
-        }
+        guildId: { type: "string", description: "The ID of the server where to set the nickname." },
+        nick: { type: "string", description: "The nickname to set for the bot. Use null or empty string to clear the nickname." }
       },
-      required: ["activityType", "activityName"]
+      required: ["guildId"]
+    }
+  },
+  {
+    name: "discord_set_about_me",
+    description: "Sets the global 'About Me' section content for the bot's Discord profile.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        aboutMe: { type: "string", description: "The global 'About Me' section content." }
+      },
+      required: ["aboutMe"]
+    }
+  },
+  {
+    name: "discord_set_bio",
+    description: "Sets the 'Bio' section content for the bot in a specified Discord server (guild).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        guildId: { type: "string", description: "The ID of the server where to set the bio." },
+        bio: { type: "string", description: "The 'Bio' section content to set for the bot in the specified server." }
+      },
+      required: ["guildId"]
     }
   }
-]; 
+];

--- a/src/toolList.ts
+++ b/src/toolList.ts
@@ -326,5 +326,43 @@ export const toolList = [
       },
       required: ["guildId"]
     }
+  },
+  {
+    name: "discord_set_bot_status",
+    description: "Sets the bot's online status (online, idle, dnd, or invisible)",
+    inputSchema: {
+      type: "object",
+      properties: {
+        status: {
+          type: "string",
+          enum: ["online", "idle", "dnd", "invisible"],
+          description: "The status to set. Options: online (green), idle (yellow/away), dnd (red/do not disturb), invisible (appears offline)"
+        }
+      },
+      required: ["status"]
+    }
+  },
+  {
+    name: "discord_set_bot_activity",
+    description: "Sets the bot's activity/presence (what the bot is doing)",
+    inputSchema: {
+      type: "object",
+      properties: {
+        activityType: {
+          type: "string",
+          enum: ["playing", "streaming", "listening", "watching", "competing", "custom"],
+          description: "The type of activity"
+        },
+        activityName: {
+          type: "string",
+          description: "The name/description of the activity"
+        },
+        url: {
+          type: "string",
+          description: "Optional URL (only used for streaming activity type, must be a valid Twitch or YouTube URL)"
+        }
+      },
+      required: ["activityType", "activityName"]
+    }
   }
 ]; 

--- a/src/tools/presence.ts
+++ b/src/tools/presence.ts
@@ -1,18 +1,17 @@
 import { z } from "zod";
 import { ToolContext, ToolResponse } from "./types.js";
-import { 
-  SetBotStatusSchema, 
-  SetBotActivitySchema 
+import {
+  SetPresenceSchema,
 } from "../schemas.js";
 import { handleDiscordError } from "../errorHandler.js";
 import { ActivityType, PresenceStatusData } from "discord.js";
 
-// Set bot status handler
-export async function setBotStatusHandler(
+// Set bot presence handler
+export async function setPresenceHandler(
   args: unknown,
   context: ToolContext
 ): Promise<ToolResponse> {
-  const { status } = SetBotStatusSchema.parse(args);
+  const { status, afk, activities } = SetPresenceSchema.parse(args);
   try {
     if (!context.client.isReady()) {
       return {
@@ -20,71 +19,30 @@ export async function setBotStatusHandler(
         isError: true
       };
     }
-
-    // Set the bot's status
-    await context.client.user?.setStatus(status as PresenceStatusData);
-
-    return {
-      content: [{ type: "text", text: `Successfully set bot status to: ${status}` }]
-    };
-  } catch (error) {
-    return handleDiscordError(error);
-  }
-}
-
-// Set bot activity/presence handler
-export async function setBotActivityHandler(
-  args: unknown,
-  context: ToolContext
-): Promise<ToolResponse> {
-  const { activityType, activityName, url } = SetBotActivitySchema.parse(args);
-  try {
-    if (!context.client.isReady()) {
-      return {
-        content: [{ type: "text", text: "Discord client not logged in." }],
-        isError: true
-      };
-    }
-
     // Map activity type string to ActivityType enum
     const activityTypeMap: Record<string, ActivityType> = {
-      "playing": ActivityType.Playing,
-      "streaming": ActivityType.Streaming,
-      "listening": ActivityType.Listening,
-      "watching": ActivityType.Watching,
-      "competing": ActivityType.Competing,
-      "custom": ActivityType.Custom
+      "PLAYING": ActivityType.Playing,
+      "STREAMING": ActivityType.Streaming,
+      "LISTENING": ActivityType.Listening,
+      "WATCHING": ActivityType.Watching,
+      "COMPETING": ActivityType.Competing,
+      "CUSTOM": ActivityType.Custom
     };
-
-    const mappedActivityType = activityTypeMap[activityType];
-    if (mappedActivityType === undefined) {
-      return {
-        content: [{ type: "text", text: `Invalid activity type: ${activityType}. Must be one of: playing, streaming, listening, watching, competing, custom` }],
-        isError: true
-      };
-    }
-
-    // Build activity options
-    const activityOptions: any = {
-      name: activityName,
-      type: mappedActivityType
-    };
-
-    // Add URL for streaming activity
-    if (activityType === "streaming" && url) {
-      activityOptions.url = url;
-    }
-
-    // Set the bot's activity
-    await context.client.user?.setActivity(activityOptions);
-
-    let responseText = `Successfully set bot activity to: ${activityType} "${activityName}"`;
-    if (activityType === "streaming" && url) {
-      responseText += ` at ${url}`;
-    }
+    // Set the bot's presence
+    context.client.user?.setPresence({
+      status: status as PresenceStatusData,
+      afk: afk ?? false,
+      activities: activities
+        ? [{
+          name: activities.name,
+          type: activityTypeMap[activities.type],
+          url: activities.url
+        }]
+        : []
+    });
 
     return {
-      content: [{ type: "text", text: responseText }]
+      content: [{ type: "text", text: `Successfully set bot presence to: ${status}` }]
     };
   } catch (error) {
     return handleDiscordError(error);

--- a/src/tools/presence.ts
+++ b/src/tools/presence.ts
@@ -78,7 +78,11 @@ export async function setNicknameHandler(
       };
     }
     // Set the bot's nickname
-    await member.setNickname(nickname);
+    if (nickname === undefined) {
+      await member.setNickname(null);
+    } else {
+      await member.setNickname(nickname);
+    }
 
     return {
       content: [{ type: "text", text: `Successfully set nickname to: ${nickname}` }]

--- a/src/tools/presence.ts
+++ b/src/tools/presence.ts
@@ -55,7 +55,7 @@ export async function setNicknameHandler(
   args: unknown,
   context: ToolContext
 ): Promise<ToolResponse> {
-  const { guildId, nickname } = SetNicknameSchema.parse(args);
+  const { guildId, nickname: nick } = SetNicknameSchema.parse(args);
   try {
     if (!context.client.isReady()) {
       return {
@@ -70,22 +70,11 @@ export async function setNicknameHandler(
         isError: true
       };
     }
-    const member = await guild.members.fetch(context.client.user!.id);
-    if (!member) {
-      return {
-        content: [{ type: "text", text: `Bot is not a member of guild ${guildId}.` }],
-        isError: true
-      };
-    }
-    // Set the bot's nickname
-    if (nickname === undefined) {
-      await member.setNickname(null);
-    } else {
-      await member.setNickname(nickname);
-    }
+
+    await guild.members.editMe({ nick: nick ?? null, reason: "Updating bot nickname via tool" });
 
     return {
-      content: [{ type: "text", text: `Successfully set nickname to: ${nickname}` }]
+      content: [{ type: "text", text: `Successfully set nickname to: ${nick}` }]
     };
   } catch (error) {
     return handleDiscordError(error);

--- a/src/tools/presence.ts
+++ b/src/tools/presence.ts
@@ -1,7 +1,8 @@
-import { z } from "zod";
 import { ToolContext, ToolResponse } from "./types.js";
 import {
   SetPresenceSchema,
+  SetAboutMeSchema,
+  SetNicknameSchema
 } from "../schemas.js";
 import { handleDiscordError } from "../errorHandler.js";
 import { ActivityType, PresenceStatusData } from "discord.js";
@@ -43,6 +44,68 @@ export async function setPresenceHandler(
 
     return {
       content: [{ type: "text", text: `Successfully set bot presence to: ${status}` }]
+    };
+  } catch (error) {
+    return handleDiscordError(error);
+  }
+}
+
+// Set nickname handler
+export async function setNicknameHandler(
+  args: unknown,
+  context: ToolContext
+): Promise<ToolResponse> {
+  const { guildId, nickname } = SetNicknameSchema.parse(args);
+  try {
+    if (!context.client.isReady()) {
+      return {
+        content: [{ type: "text", text: "Discord client not logged in." }],
+        isError: true
+      };
+    }
+    const guild = await context.client.guilds.fetch(guildId);
+    if (!guild) {
+      return {
+        content: [{ type: "text", text: `Guild with ID ${guildId} not found.` }],
+        isError: true
+      };
+    }
+    const member = await guild.members.fetch(context.client.user!.id);
+    if (!member) {
+      return {
+        content: [{ type: "text", text: `Bot is not a member of guild ${guildId}.` }],
+        isError: true
+      };
+    }
+    // Set the bot's nickname
+    await member.setNickname(nickname);
+
+    return {
+      content: [{ type: "text", text: `Successfully set nickname to: ${nickname}` }]
+    };
+  } catch (error) {
+    return handleDiscordError(error);
+  }
+}
+
+// Set bot about me handler
+export async function setAboutMeHandler(
+  args: unknown,
+  context: ToolContext
+): Promise<ToolResponse> {
+  const { aboutMe } = SetAboutMeSchema.parse(args);
+  try {
+    if (!context.client.isReady()) {
+      return {
+        content: [{ type: "text", text: "Discord client not logged in." }],
+        isError: true
+      };
+    }
+    // Set the bot's about me (bio)
+    await context.client.application.edit({ description: aboutMe });
+
+    return {
+      content: [{ type: "text", text: `Successfully updated about me section.` }]
     };
   } catch (error) {
     return handleDiscordError(error);

--- a/src/tools/presence.ts
+++ b/src/tools/presence.ts
@@ -1,0 +1,92 @@
+import { z } from "zod";
+import { ToolContext, ToolResponse } from "./types.js";
+import { 
+  SetBotStatusSchema, 
+  SetBotActivitySchema 
+} from "../schemas.js";
+import { handleDiscordError } from "../errorHandler.js";
+import { ActivityType, PresenceStatusData } from "discord.js";
+
+// Set bot status handler
+export async function setBotStatusHandler(
+  args: unknown,
+  context: ToolContext
+): Promise<ToolResponse> {
+  const { status } = SetBotStatusSchema.parse(args);
+  try {
+    if (!context.client.isReady()) {
+      return {
+        content: [{ type: "text", text: "Discord client not logged in." }],
+        isError: true
+      };
+    }
+
+    // Set the bot's status
+    await context.client.user?.setStatus(status as PresenceStatusData);
+
+    return {
+      content: [{ type: "text", text: `Successfully set bot status to: ${status}` }]
+    };
+  } catch (error) {
+    return handleDiscordError(error);
+  }
+}
+
+// Set bot activity/presence handler
+export async function setBotActivityHandler(
+  args: unknown,
+  context: ToolContext
+): Promise<ToolResponse> {
+  const { activityType, activityName, url } = SetBotActivitySchema.parse(args);
+  try {
+    if (!context.client.isReady()) {
+      return {
+        content: [{ type: "text", text: "Discord client not logged in." }],
+        isError: true
+      };
+    }
+
+    // Map activity type string to ActivityType enum
+    const activityTypeMap: Record<string, ActivityType> = {
+      "playing": ActivityType.Playing,
+      "streaming": ActivityType.Streaming,
+      "listening": ActivityType.Listening,
+      "watching": ActivityType.Watching,
+      "competing": ActivityType.Competing,
+      "custom": ActivityType.Custom
+    };
+
+    const mappedActivityType = activityTypeMap[activityType];
+    if (mappedActivityType === undefined) {
+      return {
+        content: [{ type: "text", text: `Invalid activity type: ${activityType}. Must be one of: playing, streaming, listening, watching, competing, custom` }],
+        isError: true
+      };
+    }
+
+    // Build activity options
+    const activityOptions: any = {
+      name: activityName,
+      type: mappedActivityType
+    };
+
+    // Add URL for streaming activity
+    if (activityType === "streaming" && url) {
+      activityOptions.url = url;
+    }
+
+    // Set the bot's activity
+    await context.client.user?.setActivity(activityOptions);
+
+    let responseText = `Successfully set bot activity to: ${activityType} "${activityName}"`;
+    if (activityType === "streaming" && url) {
+      responseText += ` at ${url}`;
+    }
+
+    return {
+      content: [{ type: "text", text: responseText }]
+    };
+  } catch (error) {
+    return handleDiscordError(error);
+  }
+}

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -35,6 +35,10 @@ import {
   editWebhookHandler,
   deleteWebhookHandler
 } from './webhooks.js';
+import {
+  setBotStatusHandler,
+  setBotActivityHandler
+} from './presence.js';
 
 // Export tool handlers
 export {
@@ -61,7 +65,9 @@ export {
   editCategoryHandler,
   deleteCategoryHandler,
   listServersHandler,
-  searchMessagesHandler
+  searchMessagesHandler,
+  setBotStatusHandler,
+  setBotActivityHandler
 };
 
 // Export common types

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -3,10 +3,10 @@ import { z } from "zod";
 import { ToolResponse, ToolContext, ToolHandler } from "./types.js";
 import { loginHandler } from './login.js';
 import { sendMessageHandler } from './send-message.js';
-import { 
-  getForumChannelsHandler, 
-  createForumPostHandler, 
-  getForumPostHandler, 
+import {
+  getForumChannelsHandler,
+  createForumPostHandler,
+  getForumPostHandler,
   replyToForumHandler,
   deleteForumPostHandler
 } from './forum.js';
@@ -18,8 +18,8 @@ import {
   editCategoryHandler,
   deleteCategoryHandler
 } from './channel.js';
-import { 
-  getServerInfoHandler, 
+import {
+  getServerInfoHandler,
   listServersHandler,
   searchMessagesHandler
 } from "./server.js";
@@ -36,8 +36,7 @@ import {
   deleteWebhookHandler
 } from './webhooks.js';
 import {
-  setBotStatusHandler,
-  setBotActivityHandler
+  setPresenceHandler,
 } from './presence.js';
 
 // Export tool handlers
@@ -66,8 +65,7 @@ export {
   deleteCategoryHandler,
   listServersHandler,
   searchMessagesHandler,
-  setBotStatusHandler,
-  setBotActivityHandler
+  setPresenceHandler
 };
 
 // Export common types

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -1,5 +1,4 @@
 import { Client } from "discord.js";
-import { z } from "zod";
 import { ToolResponse, ToolContext, ToolHandler } from "./types.js";
 import { loginHandler } from './login.js';
 import { sendMessageHandler } from './send-message.js';
@@ -37,6 +36,8 @@ import {
 } from './webhooks.js';
 import {
   setPresenceHandler,
+  setNicknameHandler,
+  setAboutMeHandler
 } from './presence.js';
 
 // Export tool handlers
@@ -65,7 +66,9 @@ export {
   deleteCategoryHandler,
   listServersHandler,
   searchMessagesHandler,
-  setPresenceHandler
+  setPresenceHandler,
+  setNicknameHandler,
+  setAboutMeHandler
 };
 
 // Export common types

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -37,7 +37,8 @@ import {
 import {
   setPresenceHandler,
   setNicknameHandler,
-  setAboutMeHandler
+  setAboutMeHandler,
+  setBioHandler
 } from './presence.js';
 
 // Export tool handlers
@@ -68,7 +69,8 @@ export {
   searchMessagesHandler,
   setPresenceHandler,
   setNicknameHandler,
-  setAboutMeHandler
+  setAboutMeHandler,
+  setBioHandler
 };
 
 // Export common types

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -29,7 +29,9 @@ import {
     deleteCategoryHandler,
     listServersHandler,
     searchMessagesHandler,
-    setPresenceHandler
+    setPresenceHandler,
+    setBioHandler,
+    setNicknameHandler
 } from './tools/tools.js';
 import { Client, GatewayIntentBits } from "discord.js";
 import { info, error } from './logger.js';
@@ -218,7 +220,9 @@ export class StreamableHttpTransport implements MCPTransport {
                     case 'discord_delete_category':
                     case 'discord_list_servers':
                     case 'discord_search_messages':
-                    case 'discord_set_bot_presence':
+                    case 'discord_set_presence':
+                    case 'discord_set_bio':
+                    case 'discord_set_nickname':
                         // Check if client is logged in
                         if (!this.toolContext!.client.isReady()) {
                             error(`Client not ready for method ${method}, client state: ${JSON.stringify({
@@ -345,8 +349,14 @@ export class StreamableHttpTransport implements MCPTransport {
                             case 'discord_search_messages':
                                 result = await searchMessagesHandler(params, this.toolContext!);
                                 break; break;
-                            case 'discord_set_bot_presence':
+                            case 'discord_set_presence':
                                 result = await setPresenceHandler(params, this.toolContext!);
+                                break;
+                            case 'discord_set_bio':
+                                result = await setBioHandler(params, this.toolContext!);
+                                break;
+                            case 'discord_set_nickname':
+                                result = await setNicknameHandler(params, this.toolContext!);
                                 break;
                         }
                         break;
@@ -518,10 +528,15 @@ export class StreamableHttpTransport implements MCPTransport {
                             case 'discord_search_messages':
                                 result = await searchMessagesHandler(toolArgs, this.toolContext!);
                                 break;
-                            case 'discord_set_bot_presence':
+                            case 'discord_set_presence':
                                 result = await setPresenceHandler(toolArgs, this.toolContext!);
                                 break;
-
+                            case 'discord_set_bio':
+                                result = await setBioHandler(params, this.toolContext!);
+                                break;
+                            case 'discord_set_nickname':
+                                result = await setNicknameHandler(params, this.toolContext!);
+                                break;
                             default:
                                 return res.status(400).json({
                                     jsonrpc: '2.0',

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -4,31 +4,32 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import express, { Request, Response } from "express";
 import { toolList } from './toolList.js';
 import {
-  createToolContext,
-  loginHandler,
-  sendMessageHandler,
-  getForumChannelsHandler,
-  createForumPostHandler,
-  getForumPostHandler,
-  replyToForumHandler,
-  deleteForumPostHandler,
-  createTextChannelHandler,
-  deleteChannelHandler,
-  readMessagesHandler,
-  getServerInfoHandler,
-  addReactionHandler,
-  addMultipleReactionsHandler,
-  removeReactionHandler,
-  deleteMessageHandler,
-  createWebhookHandler,
-  sendWebhookMessageHandler,
-  editWebhookHandler,
-  deleteWebhookHandler,
-  editCategoryHandler,
-  createCategoryHandler,
-  deleteCategoryHandler,
-  listServersHandler,
-  searchMessagesHandler   
+    createToolContext,
+    loginHandler,
+    sendMessageHandler,
+    getForumChannelsHandler,
+    createForumPostHandler,
+    getForumPostHandler,
+    replyToForumHandler,
+    deleteForumPostHandler,
+    createTextChannelHandler,
+    deleteChannelHandler,
+    readMessagesHandler,
+    getServerInfoHandler,
+    addReactionHandler,
+    addMultipleReactionsHandler,
+    removeReactionHandler,
+    deleteMessageHandler,
+    createWebhookHandler,
+    sendWebhookMessageHandler,
+    editWebhookHandler,
+    deleteWebhookHandler,
+    editCategoryHandler,
+    createCategoryHandler,
+    deleteCategoryHandler,
+    listServersHandler,
+    searchMessagesHandler,
+    setPresenceHandler
 } from './tools/tools.js';
 import { Client, GatewayIntentBits } from "discord.js";
 import { info, error } from './logger.js';
@@ -106,9 +107,9 @@ export class StreamableHttpTransport implements MCPTransport {
                     id: req.body?.id || null,
                 });
             }
-            
+
             info(`Request body (session ${this.sessionId}): ${JSON.stringify(req.body)}`);
-            
+
             // Handle all tool requests in a generic way
             if (!req.body.method) {
                 return res.status(400).json({
@@ -120,12 +121,12 @@ export class StreamableHttpTransport implements MCPTransport {
                     id: req.body?.id || null,
                 });
             }
-            
+
             // Handle all tools directly with proper error handling
             try {
                 const method = req.body.method;
                 const params = req.body.params || {};
-                
+
                 // Make sure toolContext is available for tool methods
                 if (!this.toolContext && method !== 'list_tools' && method !== 'initialize') {
                     return res.status(400).json({
@@ -137,9 +138,9 @@ export class StreamableHttpTransport implements MCPTransport {
                         id: req.body?.id || null,
                     });
                 }
-                
+
                 let result;
-                
+
                 // Handle each tool method directly
                 switch (method) {
                     case 'initialize':
@@ -158,7 +159,7 @@ export class StreamableHttpTransport implements MCPTransport {
                             }
                         };
                         break;
-                    
+
                     case 'notifications/initialized':
                         // Client indicates it's ready to begin normal operation
                         info("Client initialized. Starting normal operations.");
@@ -168,17 +169,17 @@ export class StreamableHttpTransport implements MCPTransport {
                             result: null,
                             id: req.body.id
                         });
-                        
+
                     case 'tools/list':
                         // New MCP method name format
                         result = { tools: toolList };
                         break;
-                        
+
                     case 'list_tools':
                         // Legacy method name for backward compatibility
                         result = { tools: toolList };
                         break;
-                        
+
                     case 'discord_login':
                         result = await loginHandler(params, this.toolContext!);
                         // Log client state after login
@@ -191,7 +192,7 @@ export class StreamableHttpTransport implements MCPTransport {
                             } : null
                         })}`);
                         break;
-                        
+
                     // Make sure Discord client is logged in for other Discord API tools 
                     // but return a proper JSON-RPC error rather than throwing an exception
                     case 'discord_send':
@@ -217,6 +218,7 @@ export class StreamableHttpTransport implements MCPTransport {
                     case 'discord_delete_category':
                     case 'discord_list_servers':
                     case 'discord_search_messages':
+                    case 'discord_set_bot_presence':
                         // Check if client is logged in
                         if (!this.toolContext!.client.isReady()) {
                             error(`Client not ready for method ${method}, client state: ${JSON.stringify({
@@ -227,7 +229,7 @@ export class StreamableHttpTransport implements MCPTransport {
                                     tag: this.toolContext!.client.user.tag,
                                 } : null
                             })}`);
-                            
+
                             // Check if we have a token but not ready - try to force reconnect
                             if (this.toolContext!.client.token) {
                                 info("Has token but not ready - attempting to force reconnect");
@@ -235,7 +237,7 @@ export class StreamableHttpTransport implements MCPTransport {
                                     // Attempt to force login with existing token
                                     await this.toolContext!.client.login(this.toolContext!.client.token);
                                     info(`Force reconnect successful: ${this.toolContext!.client.isReady()}`);
-                                    
+
                                     // If still not ready after reconnect, return error
                                     if (!this.toolContext!.client.isReady()) {
                                         return res.json({
@@ -247,7 +249,7 @@ export class StreamableHttpTransport implements MCPTransport {
                                             id: req.body?.id || null,
                                         });
                                     }
-                                    
+
                                     // Continue with original request as now logged in
                                     info("Reconnected successfully, continuing with original request");
                                 } catch (reconnectError) {
@@ -272,7 +274,7 @@ export class StreamableHttpTransport implements MCPTransport {
                                 });
                             }
                         }
-                        
+
                         // Call appropriate handler based on method
                         switch (method) {
                             case 'discord_send':
@@ -342,20 +344,23 @@ export class StreamableHttpTransport implements MCPTransport {
                                 result = await listServersHandler(params, this.toolContext!);
                             case 'discord_search_messages':
                                 result = await searchMessagesHandler(params, this.toolContext!);
-                                break;break;
+                                break; break;
+                            case 'discord_set_bot_presence':
+                                result = await setPresenceHandler(params, this.toolContext!);
+                                break;
                         }
                         break;
-                        
-                
-                        
+
+
+
                     case 'tools/call':
                         // Handle new tools/call method format
                         const toolName = params.name;
                         const toolArgs = params.arguments || {};
-                        
+
                         // Check if Discord client is logged in for Discord API tools
-                        if (toolName !== 'discord_login' && 
-                            toolName.startsWith('discord_') && 
+                        if (toolName !== 'discord_login' &&
+                            toolName.startsWith('discord_') &&
                             !this.toolContext!.client.isReady()) {
                             error(`Client not ready for tool ${toolName}, client state: ${JSON.stringify({
                                 isReady: this.toolContext!.client.isReady(),
@@ -365,7 +370,7 @@ export class StreamableHttpTransport implements MCPTransport {
                                     tag: this.toolContext!.client.user.tag,
                                 } : null
                             })}`);
-                            
+
                             // Check if we have a token but not ready - try to force reconnect
                             if (this.toolContext!.client.token) {
                                 info("Has token but not ready - attempting to force reconnect");
@@ -373,7 +378,7 @@ export class StreamableHttpTransport implements MCPTransport {
                                     // Attempt to force login with existing token
                                     await this.toolContext!.client.login(this.toolContext!.client.token);
                                     info(`Force reconnect successful: ${this.toolContext!.client.isReady()}`);
-                                    
+
                                     // If still not ready after reconnect, return error
                                     if (!this.toolContext!.client.isReady()) {
                                         return res.json({
@@ -385,7 +390,7 @@ export class StreamableHttpTransport implements MCPTransport {
                                             id: req.body?.id || null,
                                         });
                                     }
-                                    
+
                                     // Continue with original request as now logged in
                                     info("Reconnected successfully, continuing with original request");
                                 } catch (reconnectError) {
@@ -410,7 +415,7 @@ export class StreamableHttpTransport implements MCPTransport {
                                 });
                             }
                         }
-                        
+
                         // Call the appropriate handler based on tool name
                         switch (toolName) {
                             case 'discord_login':
@@ -425,75 +430,75 @@ export class StreamableHttpTransport implements MCPTransport {
                                     } : null
                                 })}`);
                                 break;
-                                
+
                             case 'discord_send':
                                 result = await sendMessageHandler(toolArgs, this.toolContext!);
                                 break;
-                                
+
                             case 'discord_get_forum_channels':
                                 result = await getForumChannelsHandler(toolArgs, this.toolContext!);
                                 break;
-                                
+
                             case 'discord_create_forum_post':
                                 result = await createForumPostHandler(toolArgs, this.toolContext!);
                                 break;
-                                
+
                             case 'discord_get_forum_post':
                                 result = await getForumPostHandler(toolArgs, this.toolContext!);
                                 break;
-                                
+
                             case 'discord_reply_to_forum':
                                 result = await replyToForumHandler(toolArgs, this.toolContext!);
                                 break;
-                                
+
                             case 'discord_delete_forum_post':
                                 result = await deleteForumPostHandler(toolArgs, this.toolContext!);
                                 break;
-                                
+
                             case 'discord_create_text_channel':
                                 result = await createTextChannelHandler(toolArgs, this.toolContext!);
                                 break;
-                                
+
                             case 'discord_delete_channel':
                                 result = await deleteChannelHandler(toolArgs, this.toolContext!);
                                 break;
-                                
+
                             case 'discord_read_messages':
                                 result = await readMessagesHandler(toolArgs, this.toolContext!);
                                 break;
-                                
+
                             case 'discord_get_server_info':
                                 result = await getServerInfoHandler(toolArgs, this.toolContext!);
                                 break;
-                                
+
                             case 'discord_add_reaction':
                                 result = await addReactionHandler(toolArgs, this.toolContext!);
                                 break;
-                                
+
                             case 'discord_add_multiple_reactions':
                                 result = await addMultipleReactionsHandler(toolArgs, this.toolContext!);
                                 break;
-                                
+
                             case 'discord_remove_reaction':
                                 result = await removeReactionHandler(toolArgs, this.toolContext!);
                                 break;
-                                
+
                             case 'discord_delete_message':
                                 result = await deleteMessageHandler(toolArgs, this.toolContext!);
                                 break;
-                                
+
                             case 'discord_create_webhook':
                                 result = await createWebhookHandler(toolArgs, this.toolContext!);
                                 break;
-                                
+
                             case 'discord_send_webhook_message':
                                 result = await sendWebhookMessageHandler(toolArgs, this.toolContext!);
                                 break;
-                                
+
                             case 'discord_edit_webhook':
                                 result = await editWebhookHandler(toolArgs, this.toolContext!);
                                 break;
-                                
+
                             case 'discord_delete_webhook':
                                 result = await deleteWebhookHandler(toolArgs, this.toolContext!);
                                 break;
@@ -506,14 +511,17 @@ export class StreamableHttpTransport implements MCPTransport {
                             case 'discord_delete_category':
                                 result = await deleteCategoryHandler(toolArgs, this.toolContext!);
                                 break;
-                            
+
                             case 'discord_list_servers':
                                 result = await listServersHandler(toolArgs, this.toolContext!);
                                 break;
                             case 'discord_search_messages':
                                 result = await searchMessagesHandler(toolArgs, this.toolContext!);
                                 break;
-                                
+                            case 'discord_set_bot_presence':
+                                result = await setPresenceHandler(toolArgs, this.toolContext!);
+                                break;
+
                             default:
                                 return res.status(400).json({
                                     jsonrpc: '2.0',
@@ -525,7 +533,7 @@ export class StreamableHttpTransport implements MCPTransport {
                                 });
                         }
                         break;
-                        
+
                     default:
                         // For method 'ping' and other non-critical methods, just return an empty result
                         // This ensures MCP compatibility for health checks and probes
@@ -544,9 +552,9 @@ export class StreamableHttpTransport implements MCPTransport {
                             });
                         }
                 }
-                
+
                 info(`Request for ${method} handled successfully`);
-                
+
                 // Handle the case where tool handlers return { content, isError }
                 if (result && typeof result === 'object' && 'content' in result) {
                     // If it's an error from the tool handler
@@ -557,13 +565,13 @@ export class StreamableHttpTransport implements MCPTransport {
                             id: req.body.id,
                             error: {
                                 code: -32603,
-                                message: Array.isArray(result.content) 
-                                    ? result.content.map((item: any) => item.text).join(' ') 
+                                message: Array.isArray(result.content)
+                                    ? result.content.map((item: any) => item.text).join(' ')
                                     : 'Tool execution error'
                             }
                         });
                     }
-                    
+
                     // Return success result but maintain same format as other RPC methods
                     const finalResponse = {
                         jsonrpc: '2.0',
@@ -573,7 +581,7 @@ export class StreamableHttpTransport implements MCPTransport {
                     info(`Sending response (session ${this.sessionId}): ${JSON.stringify(finalResponse)}`);
                     return res.json(finalResponse);
                 }
-                
+
                 // Standard result format
                 const finalResponse = {
                     jsonrpc: '2.0',
@@ -582,7 +590,7 @@ export class StreamableHttpTransport implements MCPTransport {
                 };
                 info(`Sending response (session ${this.sessionId}): ${JSON.stringify(finalResponse)}`);
                 return res.json(finalResponse);
-                
+
             } catch (err) {
                 error('Error processing tool request: ' + String(err));
                 // Handle validation errors
@@ -606,7 +614,7 @@ export class StreamableHttpTransport implements MCPTransport {
                     id: req.body?.id || null,
                 });
             }
-            
+
         } catch (err) {
             error('Error handling MCP request: ' + String(err));
             if (!res.headersSent) {
@@ -625,18 +633,18 @@ export class StreamableHttpTransport implements MCPTransport {
     async start(server: Server): Promise<void> {
         this.server = server;
         info('Starting HTTP transport with server: ' + String(!!this.server));
-        
+
         // Try to get client from the DiscordMCPServer instance
         // First, check if the server is passed from DiscordMCPServer
         if (server) {
             // Try to access client directly from server._context
             const anyServer = server as any;
             let client: Client | undefined;
-            
+
             if (anyServer._context?.client) {
                 client = anyServer._context.client;
                 info('Found client in server._context');
-            } 
+            }
             // Also check if the server object has client directly
             else if (anyServer.client instanceof Client) {
                 client = anyServer.client;
@@ -647,7 +655,7 @@ export class StreamableHttpTransport implements MCPTransport {
                 client = anyServer._parent.client;
                 info('Found client in server._parent');
             }
-            
+
             if (client) {
                 this.toolContext = createToolContext(client);
                 info('Tool context initialized with Discord client');
@@ -666,12 +674,12 @@ export class StreamableHttpTransport implements MCPTransport {
                 info('Tool context initialized with new Discord client');
             }
         }
-        
+
         // Create a stateless transport
         this.transport = new StreamableHTTPServerTransport({
             sessionIdGenerator: undefined // set to undefined for stateless servers
         });
-        
+
         // Connect the transport
         await this.server.connect(this.transport);
         info('Transport connected');


### PR DESCRIPTION
This pull request adds new capabilities for managing the bot's presence, nickname, bio, and global "About Me" information. It introduces these new tools in `tools/presence.ts`:

- `discord_set_presence`: Sets the bot's presence (status and activity) in Discord.
- `discord_set_nickname`: Sets the bot's nickname on a server.
- `discord_set_bio`: Sets the bot's bio on a server.
- `discord_set_about_me`: Sets the bot's About Me information.
