### PR TITLE
feat: expose reactions in read_messages + add get_reaction_users tool

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -53,6 +53,7 @@ function createMcpServer(client: Client) {
         { name: 'discord_add_reaction', schema: schemas.AddReactionSchema, handler: handlers.addReactionHandler },
         { name: 'discord_add_multiple_reactions', schema: schemas.AddMultipleReactionsSchema, handler: handlers.addMultipleReactionsHandler },
         { name: 'discord_remove_reaction', schema: schemas.RemoveReactionSchema, handler: handlers.removeReactionHandler },
+        { name: 'discord_get_reaction_users', schema: schemas.GetReactionUsersSchema, handler: handlers.getReactionUsersHandler },
         { name: 'discord_delete_message', schema: schemas.DeleteMessageSchema, handler: handlers.deleteMessageHandler },
         { name: 'discord_create_webhook', schema: schemas.CreateWebhookSchema, handler: handlers.createWebhookHandler },
         { name: 'discord_send_webhook_message', schema: schemas.SendWebhookMessageSchema, handler: handlers.sendWebhookMessageHandler },

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -152,6 +152,15 @@ export const RemoveReactionSchema = z.object({
     description: "Remove a reaction from a specific message in a channel."
 });
 
+export const GetReactionUsersSchema = z.object({
+    channelId: z.string({ description: "The ID of the channel containing the message." }),
+    messageId: z.string({ description: "The ID of the message to inspect reactions on." }),
+    emoji: z.string({ description: "The emoji whose reactors should be listed (unicode name or custom emoji name)." }),
+    limit: z.number({ description: "Maximum number of users to fetch per reaction (1-100, default 100)." }).int().min(1).max(100).default(100).optional()
+}, {
+    description: "List the users who reacted with a specific emoji to a message. Uses REST fetch and does not require Gateway intents."
+});
+
 export const DeleteForumPostSchema = z.object({
     threadId: z.string({ description: "The ID of the forum thread to delete." }),
     reason: z.string({ description: "Optional reason for audit logs when deleting the forum post." }).optional()

--- a/src/server.ts
+++ b/src/server.ts
@@ -29,6 +29,7 @@ import {
   addReactionHandler,
   addMultipleReactionsHandler,
   removeReactionHandler,
+  getReactionUsersHandler,
   deleteMessageHandler,
   createWebhookHandler,
   sendWebhookMessageHandler,
@@ -206,6 +207,11 @@ export class DiscordMCPServer {
           case "discord_remove_reaction":
             this.logClientState("before discord_remove_reaction handler");
             toolResponse = await removeReactionHandler(args, this.toolContext);
+            return toolResponse;
+
+          case "discord_get_reaction_users":
+            this.logClientState("before discord_get_reaction_users handler");
+            toolResponse = await getReactionUsersHandler(args, this.toolContext);
             return toolResponse;
 
           case "discord_delete_message":

--- a/src/toolList.ts
+++ b/src/toolList.ts
@@ -258,6 +258,25 @@ export const toolList = [
     }
   },
   {
+    name: "discord_get_reaction_users",
+    description: "Lists the users who reacted with a specific emoji to a Discord message. Uses REST fetch and does not require Gateway intents. Returns up to 100 users per call.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        channelId: { type: "string" },
+        messageId: { type: "string" },
+        emoji: { type: "string", description: "Unicode emoji name (e.g. '🟢') or custom emoji name." },
+        limit: {
+          type: "number",
+          minimum: 1,
+          maximum: 100,
+          default: 100
+        }
+      },
+      required: ["channelId", "messageId", "emoji"]
+    }
+  },
+  {
     name: "discord_delete_forum_post",
     description: "Deletes a forum post or thread with an optional reason",
     inputSchema: {

--- a/src/tools/channel.ts
+++ b/src/tools/channel.ts
@@ -333,7 +333,7 @@ export async function readMessagesHandler(
       };
     }
 
-    // Format messages 
+    // Format messages
     const formattedMessages = messages.map(msg => ({
       id: msg.id,
       content: msg.content,
@@ -345,7 +345,16 @@ export async function readMessagesHandler(
       timestamp: msg.createdAt,
       attachments: msg.attachments.size,
       embeds: msg.embeds.length,
-      replyTo: msg.reference ? msg.reference.messageId : null
+      replyTo: msg.reference ? msg.reference.messageId : null,
+      // Expose reactions populated by REST fetch (no Gateway intent required).
+      // Each entry includes the unicode/custom emoji name+id, total count, and
+      // whether the bot itself reacted. User IDs are not listed here to keep the
+      // payload small; use discord_get_reaction_users for that.
+      reactions: msg.reactions.cache.map(r => ({
+        emoji: { name: r.emoji.name, id: r.emoji.id },
+        count: r.count,
+        me: r.me
+      }))
     })).sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
 
     return {

--- a/src/tools/reactions.ts
+++ b/src/tools/reactions.ts
@@ -1,10 +1,11 @@
 import { z } from "zod";
 import { ToolContext, ToolResponse } from "./types.js";
-import { 
-  AddReactionSchema, 
-  AddMultipleReactionsSchema, 
+import {
+  AddReactionSchema,
+  AddMultipleReactionsSchema,
   RemoveReactionSchema,
-  DeleteMessageSchema
+  DeleteMessageSchema,
+  GetReactionUsersSchema
 } from "../schemas.js";
 import { handleDiscordError } from "../errorHandler.js";
 
@@ -162,6 +163,81 @@ export async function removeReactionHandler(
         }]
       };
     }
+  } catch (error) {
+    return handleDiscordError(error);
+  }
+}
+
+// Get reaction users handler
+export async function getReactionUsersHandler(
+  args: unknown,
+  context: ToolContext
+): Promise<ToolResponse> {
+  const { channelId, messageId, emoji, limit } = GetReactionUsersSchema.parse(args);
+  try {
+    if (!context.client.isReady()) {
+      return {
+        content: [{ type: "text", text: "Discord client not logged in." }],
+        isError: true
+      };
+    }
+
+    const channel = await context.client.channels.fetch(channelId);
+    if (!channel || !channel.isTextBased() || !('messages' in channel)) {
+      return {
+        content: [{ type: "text", text: `Cannot find text channel with ID: ${channelId}` }],
+        isError: true
+      };
+    }
+
+    const message = await channel.messages.fetch(messageId);
+    if (!message) {
+      return {
+        content: [{ type: "text", text: `Cannot find message with ID: ${messageId}` }],
+        isError: true
+      };
+    }
+
+    const reaction = message.reactions.cache.find(
+      r => r.emoji.toString() === emoji || r.emoji.name === emoji
+    );
+
+    if (!reaction) {
+      return {
+        content: [{
+          type: "text",
+          text: JSON.stringify({
+            channelId,
+            messageId,
+            emoji,
+            count: 0,
+            users: []
+          }, null, 2)
+        }]
+      };
+    }
+
+    // REST-based user list fetch; no Gateway intent required.
+    const users = await reaction.users.fetch({ limit: limit ?? 100 });
+    const formattedUsers = users.map(u => ({
+      id: u.id,
+      username: u.username,
+      bot: u.bot
+    }));
+
+    return {
+      content: [{
+        type: "text",
+        text: JSON.stringify({
+          channelId,
+          messageId,
+          emoji: { name: reaction.emoji.name, id: reaction.emoji.id },
+          count: reaction.count,
+          me: reaction.me,
+          users: formattedUsers
+        }, null, 2)
+      }]
+    };
   } catch (error) {
     return handleDiscordError(error);
   }

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -36,6 +36,7 @@ import {
   addReactionHandler,
   addMultipleReactionsHandler,
   removeReactionHandler,
+  getReactionUsersHandler,
   deleteMessageHandler
 } from './reactions.js';
 import {
@@ -78,6 +79,7 @@ export {
   addReactionHandler,
   addMultipleReactionsHandler,
   removeReactionHandler,
+  getReactionUsersHandler,
   deleteMessageHandler,
   createWebhookHandler,
   sendWebhookMessageHandler,


### PR DESCRIPTION
## Summary
- Add `reactions` field to `discord_read_messages` response (emoji.name / emoji.id / count / me)
- Add new tool `discord_get_reaction_users` to list reactors' user IDs via REST
- Both work without Gateway intents — they expose data already populated by the existing REST `messages.fetch()` call

## Motivation
`discord.js` populates `Message.reactions.cache` whenever a message is fetched via REST, but the current `readMessagesHandler` formatter omits this field. As a result, downstream agents/integrations cannot:
- Detect emoji-based approval reactions on bot-posted messages
- Collect quality feedback signals via reactions
- Identify which user reacted (without subscribing to the Gateway)

This PR makes both possible with REST-only fetches, no extra intents required.

## Changes
| File | Change |
|---|---|
| `src/tools/channel.ts` | `readMessagesHandler` formatter now emits `reactions: [{emoji:{name,id}, count, me}]` |
| `src/tools/reactions.ts` | New `getReactionUsersHandler` calling `MessageReaction.users.fetch({limit})` |
| `src/schemas.ts` | New `GetReactionUsersSchema` (channelId / messageId / emoji / limit 1-100) |
| `src/tools/tools.ts` | Export new handler |
| `src/toolList.ts` | New `discord_get_reaction_users` tool definition |
| `src/server.ts` | Dispatcher case for new tool |
| `src/app.ts` | Registration for new tool |

## Test plan
- [x] `npm run build` passes (tsc)
- [x] Backwards compatible: `read_messages` response only **adds** a field; existing fields unchanged
- [ ] Manual check on a test channel: post a message, react with bot + user, call `read_messages` → confirm `reactions` field shape; call `get_reaction_users` → confirm `users[]` includes the right IDs

## Notes
- No new dependencies
- No changes to existing behavior of `add_reaction` / `remove_reaction` / `add_multiple_reactions`
- Bot permissions required: `View Channel` + `Read Message History` (already required for `read_messages`); reading reactions and reactor lists does not need additional scopes