### PR TITLE
Fix MCP protocol violations and stdio shutdown hang

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -114,26 +114,49 @@ try {
     await mcpServer.start();
     info('MCP server started successfully');
     
+    // Unified shutdown, registered for every transport. In stdio mode there
+    // was previously no shutdown path at all, so the health-check interval and
+    // the discord.js client kept the event loop alive until the host SIGKILLed
+    // the process (~185s). Route every termination trigger through one
+    // idempotent, bounded shutdown.
+    let heartbeat: NodeJS.Timeout | null = null;
+    let shuttingDown = false;
+
+    const shutdown = async (reason: string) => {
+        if (shuttingDown) return;            // idempotent
+        shuttingDown = true;
+        error(`Shutting down (${reason})...`);
+
+        // Bounded: if graceful close stalls (e.g. a hung Discord WS), force exit.
+        const force = setTimeout(() => {
+            error('Graceful shutdown timed out; forcing exit.');
+            process.exit(0);
+        }, 3000);
+        force.unref();                       // don't let the backstop itself pin the loop
+
+        if (heartbeat) { clearInterval(heartbeat); heartbeat = null; }
+        try {
+            await mcpServer.stop();          // clears health interval, closes transport, destroys client
+        } catch (err) {
+            error('Error during shutdown: ' + String(err));
+        }
+        process.exit(0);
+    };
+
+    process.on('SIGINT', () => shutdown('SIGINT'));
+    process.on('SIGTERM', () => shutdown('SIGTERM'));
+    // Gateway closing the pipe: a pipe writer-close surfaces as 'close', while a
+    // plain EOF surfaces as 'end'. Handle both; shutdown() is idempotent.
+    process.stdin.on('close', () => shutdown('stdin close'));
+    process.stdin.on('end', () => shutdown('stdin end'));
+
     // Keep the Node.js process running
     if (config.TRANSPORT.toLowerCase() === 'http') {
         // Send a heartbeat every 30 seconds to keep the process alive
-        setInterval(() => {
+        heartbeat = setInterval(() => {
             info('MCP server is running');
         }, 30000);
-        
-        // Handle termination signals
-        process.on('SIGINT', async () => {
-            info('Received SIGINT. Shutting down server...');
-            await mcpServer.stop();
-            process.exit(0);
-        });
-        
-        process.on('SIGTERM', async () => {
-            info('Received SIGTERM. Shutting down server...');
-            await mcpServer.stop();
-            process.exit(0);
-        });
-        
+
         info('Server running in keep-alive mode. Press Ctrl+C to stop.');
     }
 } catch (err) {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,13 +1,7 @@
 export function log(message: string, level: 'info' | 'error' = 'info') {
-    const logMessage = {
-        jsonrpc: '2.0',
-        method: 'log',
-        params: {
-            level,
-            message
-        }
-    };
-    process.stdout.write(JSON.stringify(logMessage) + '\n');
+    // Diagnostics must go to stderr: in stdio mode stdout is the JSON-RPC
+    // channel, and writing anything else there corrupts the protocol stream.
+    process.stderr.write(`[${level}] ${message}\n`);
 }
 
 export function info(message: string) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -55,6 +55,8 @@ import {
 import { MCPTransport } from './transport.js';
 import { info, error } from './logger.js';
 
+const CLIENT_STATE_LOG_INTERVAL_MS = 5 * 60 * 1000; // was 10_000
+
 export class DiscordMCPServer {
   private server: Server;
   private toolContext: ReturnType<typeof createToolContext>;
@@ -337,7 +339,7 @@ export class DiscordMCPServer {
     // Setup periodic client state logging
     this.clientStatusInterval = setInterval(() => {
       this.logClientState("periodic check");
-    }, 10000);
+    }, CLIENT_STATE_LOG_INTERVAL_MS);
     
     await this.transport.start(this.server);
   }
@@ -348,7 +350,16 @@ export class DiscordMCPServer {
       clearInterval(this.clientStatusInterval);
       this.clientStatusInterval = null;
     }
-    
+
     await this.transport.stop();
+
+    // Tear down the discord.js client so its WebSocket and internal
+    // heartbeats stop pinning the event loop. Guarded so a stalled
+    // connection can't throw past shutdown.
+    try {
+      await this.client.destroy();
+    } catch (err) {
+      error('Error destroying Discord client: ' + String(err));
+    }
   }
 } 


### PR DESCRIPTION
## Summary

Fixes two related problems observed running this server under a long-lived agent gateway over **stdio**.

### 1. Malformed log notifications (MCP protocol violation)
Internal diagnostics were emitted as hand-rolled `method:"log"` JSON-RPC notifications written to **stdout**. This is non-compliant with the MCP server→client logging spec (which is `notifications/message` with `params:{level, logger?, data}`) and — worse — corrupts the stdio JSON-RPC stream, since stdout is reserved for the protocol. Clients reject these with `Failed to validate notification ... ServerNotification`.

**Fix:** route internal diagnostics to **stderr** (`src/logger.ts`), keeping the existing `log`/`info`/`error` API so no call sites change. stdout is now a clean JSON-RPC channel.

### 2. Process does not exit on shutdown (~185s until SIGKILL)
In **stdio mode there was no shutdown path at all** — `SIGINT`/`SIGTERM` handlers were registered only for the HTTP transport, so `mcpServer.stop()` was never called. As a result:
- the 10s health-check `setInterval` was never cleared, pinning the event loop;
- the discord.js client was never `destroy()`ed, leaving its WebSocket + internal heartbeats alive.

**Fix:**
- `src/index.ts`: a single **idempotent, bounded** `shutdown()` wired to `SIGINT`, `SIGTERM`, and stdin `close`/`end`, registered for **all** transports. It clears timers, calls `mcpServer.stop()`, and force-exits after a 3s backstop if graceful close stalls (e.g. a hung Discord WS).
- `src/server.ts`: `stop()` now also `client.destroy()`s the discord.js client (guarded).

### 3. Over-chatty health log
The "periodic check" client-state log fired every 10s. Lengthened to **5 minutes** (`src/server.ts`), cleanup unchanged.

## Verification
- `npm run build` compiles cleanly.
- `build/index.js` (stdio): diagnostics now appear on **stderr**; stdout carries only JSON-RPC.
- On `SIGTERM`, the process exits within **~0s** (previously ~185s). `process.getActiveResourcesInfo()` confirms the health-check timer and Discord client handles are gone after cleanup.

Note: the alternate `src/app.ts` entry point was intentionally left untouched to keep this change focused; it already logs to stderr / uses the SDK's `sendLoggingMessage`. Happy to follow up there for parity if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)