### PR TITLE
test: enable the Jest suite and align stale assertions

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,6 +5,9 @@ const tsJestTransformCfg = createDefaultPreset().transform;
 /** @type {import("jest").Config} **/
 export default {
   testEnvironment: "node",
+  roots: ["<rootDir>/src"],
+  testMatch: ["**/*.test.ts"],
+  testPathIgnorePatterns: ["/build/", "/node_modules/"],
   transform: {
     ...tsJestTransformCfg,
   },

--- a/package.json
+++ b/package.json
@@ -8,14 +8,14 @@
   },
   "type": "module",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest --runInBand",
     "build": "tsc",
     "start": "node build/index.js",
     "start-app": "node build/app.js",
     "dev": "node --loader ts-node/esm src/index.ts",
     "dev-app": "node --loader ts-node/esm src/app.ts",
     "test-api": "node test-api.js",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm test && npm run build"
   },
   "keywords": [
     "mcp",

--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -1,170 +1,29 @@
-import { log, info, error } from './logger.js';
+import { error, info, log } from './logger.js';
 
-// Mock process.stdout.write to capture log output
-const mockStdoutWrite = jest.fn();
-
-describe('Logger', () => {
-    let originalStdoutWrite: typeof process.stdout.write;
+describe('protocol-safe logger', () => {
+    let stderrWrite: jest.SpyInstance;
+    let stdoutWrite: jest.SpyInstance;
 
     beforeEach(() => {
-        // Save original function
-        originalStdoutWrite = process.stdout.write;
-        // Mock the function
-        process.stdout.write = mockStdoutWrite;
-        // Clear previous calls
-        mockStdoutWrite.mockClear();
+        stderrWrite = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+        stdoutWrite = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
     });
 
-    afterEach(() => {
-        // Restore original function
-        process.stdout.write = originalStdoutWrite;
+    afterEach(() => jest.restoreAllMocks());
+
+    it('writes diagnostics only to stderr', () => {
+        log('message');
+        expect(stderrWrite).toHaveBeenCalledWith('[info] message\n');
+        expect(stdoutWrite).not.toHaveBeenCalled();
     });
 
-    describe('log', () => {
-        it('should log with default info level when no level is provided', () => {
-            log('Test message');
-            
-            expect(mockStdoutWrite).toHaveBeenCalledTimes(1);
-            const [call] = mockStdoutWrite.mock.calls;
-            const jsonStr = call[0];
-            const parsedLog = JSON.parse(jsonStr);
-            
-            expect(parsedLog).toEqual({
-                jsonrpc: '2.0',
-                method: 'log',
-                params: {
-                    level: 'info',
-                    message: 'Test message'
-                }
-            });
-            
-            // Ensure the log ends with a newline
-            expect(jsonStr.endsWith('\n')).toBe(true);
-        });
-
-        it('should log with specified info level', () => {
-            log('Info message', 'info');
-            
-            expect(mockStdoutWrite).toHaveBeenCalledTimes(1);
-            const [call] = mockStdoutWrite.mock.calls;
-            const jsonStr = call[0];
-            const parsedLog = JSON.parse(jsonStr);
-            
-            expect(parsedLog).toEqual({
-                jsonrpc: '2.0',
-                method: 'log',
-                params: {
-                    level: 'info',
-                    message: 'Info message'
-                }
-            });
-        });
-
-        it('should log with specified error level', () => {
-            log('Error message', 'error');
-            
-            expect(mockStdoutWrite).toHaveBeenCalledTimes(1);
-            const [call] = mockStdoutWrite.mock.calls;
-            const jsonStr = call[0];
-            const parsedLog = JSON.parse(jsonStr);
-            
-            expect(parsedLog).toEqual({
-                jsonrpc: '2.0',
-                method: 'log',
-                params: {
-                    level: 'error',
-                    message: 'Error message'
-                }
-            });
-        });
-
-        it('should properly format the JSON-RPC message structure', () => {
-            log('Test message', 'info');
-            
-            const [call] = mockStdoutWrite.mock.calls;
-            const jsonStr = call[0];
-            const parsedLog = JSON.parse(jsonStr);
-            
-            expect(parsedLog).toHaveProperty('jsonrpc', '2.0');
-            expect(parsedLog).toHaveProperty('method', 'log');
-            expect(parsedLog).toHaveProperty('params');
-            expect(parsedLog.params).toHaveProperty('level');
-            expect(parsedLog.params).toHaveProperty('message');
-        });
+    it('labels info messages', () => {
+        info('ready');
+        expect(stderrWrite).toHaveBeenCalledWith('[info] ready\n');
     });
 
-    describe('info', () => {
-        it('should call log with info level', () => {
-            const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
-            info('Info message');
-            logSpy.mockRestore();
-            
-            expect(mockStdoutWrite).toHaveBeenCalledTimes(1);
-            const [call] = mockStdoutWrite.mock.calls;
-            const jsonStr = call[0];
-            const parsedLog = JSON.parse(jsonStr);
-            
-            expect(parsedLog).toEqual({
-                jsonrpc: '2.0',
-                method: 'log',
-                params: {
-                    level: 'info',
-                    message: 'Info message'
-                }
-            });
-        });
-    });
-
-    describe('error', () => {
-        it('should call log with error level', () => {
-            const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
-            error('Error message');
-            logSpy.mockRestore();
-            
-            expect(mockStdoutWrite).toHaveBeenCalledTimes(1);
-            const [call] = mockStdoutWrite.mock.calls;
-            const jsonStr = call[0];
-            const parsedLog = JSON.parse(jsonStr);
-            
-            expect(parsedLog).toEqual({
-                jsonrpc: '2.0',
-                method: 'log',
-                params: {
-                    level: 'error',
-                    message: 'Error message'
-                }
-            });
-        });
-    });
-
-    describe('output formatting', () => {
-        it('should append newline character to the output', () => {
-            log('Test message', 'info');
-            
-            const [call] = mockStdoutWrite.mock.calls;
-            const output = call[0];
-            
-            expect(output).toMatch(/\n$/);
-        });
-
-        it('should write stringified JSON to stdout', () => {
-            log('Test message', 'info');
-            
-            const [call] = mockStdoutWrite.mock.calls;
-            const output = call[0].slice(0, -1); // Remove newline for parsing
-            
-            // Should be valid JSON
-            expect(() => JSON.parse(output)).not.toThrow();
-            
-            const parsed = JSON.parse(output);
-            expect(parsed).toEqual({
-                jsonrpc: '2.0',
-                method: 'log',
-                params: {
-                    level: 'info',
-                    message: 'Test message'
-                }
-            });
-        });
+    it('labels error messages', () => {
+        error('failed');
+        expect(stderrWrite).toHaveBeenCalledWith('[error] failed\n');
     });
 });

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -64,6 +64,7 @@ const mockedTransport = {
 
 const mockedClient = {
   isReady: jest.fn(),
+  destroy: jest.fn().mockResolvedValue(undefined),
   user: null,
   token: null,
 };
@@ -639,7 +640,7 @@ describe('DiscordMCPServer', () => {
       await discordMCPServer.start();
 
       expect(mockTransport.start).toHaveBeenCalledWith(mockServer);
-      expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 10000);
+      expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 300000);
 
       // Clean up timer
       jest.useRealTimers();
@@ -665,6 +666,7 @@ describe('DiscordMCPServer', () => {
 
       expect(clearIntervalSpy).toHaveBeenCalled();
       expect(mockTransport.stop).toHaveBeenCalled();
+      expect(mockClient.destroy).toHaveBeenCalled();
       jest.useRealTimers();
     });
 


### PR DESCRIPTION
## Summary

Enable the Jest suite already present in the repository and update stale assertions to match behavior currently on `main`.

## Why

`npm test` currently exits with "no test specified." Running Jest directly also discovers compiled tests under `build/`, causing duplicate execution and ESM parsing failures.

After restricting discovery to source TypeScript tests, two expectations needed to follow current behavior:

- Logger diagnostics now use stderr so they cannot corrupt the stdio JSON-RPC stream.
- The client-status interval is currently five minutes rather than ten seconds.

The shutdown test also verifies the existing `client.destroy()` call.

## Result

```text
17 test suites passed
360 tests passed
TypeScript build passed
```

`prepublishOnly` now runs the suite before building the package.