### PR TITLE
fix: destroy Discord after transport shutdown failure

### DIFF
--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -64,6 +64,7 @@ const mockedTransport = {
 
 const mockedClient = {
   isReady: jest.fn(),
+  destroy: jest.fn().mockResolvedValue(undefined),
   user: null,
   token: null,
 };
@@ -673,6 +674,13 @@ describe('DiscordMCPServer', () => {
       await discordMCPServer.stop();
 
       expect(mockTransport.stop).toHaveBeenCalled();
+    });
+
+    it('should destroy Discord even when transport shutdown rejects', async () => {
+      mockTransport.stop.mockRejectedValueOnce(new Error('transport close failed'));
+
+      await expect(discordMCPServer.stop()).rejects.toThrow('transport close failed');
+      expect(mockClient.destroy).toHaveBeenCalled();
     });
   });
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -351,15 +351,22 @@ export class DiscordMCPServer {
       this.clientStatusInterval = null;
     }
 
-    await this.transport.stop();
-
-    // Tear down the discord.js client so its WebSocket and internal
-    // heartbeats stop pinning the event loop. Guarded so a stalled
-    // connection can't throw past shutdown.
+    let transportError: unknown;
     try {
-      await this.client.destroy();
+      await this.transport.stop();
     } catch (err) {
-      error('Error destroying Discord client: ' + String(err));
+      transportError = err;
+      error('Error stopping MCP transport: ' + String(err));
+    } finally {
+      // Always tear down Discord, even if transport cleanup fails.
+      try {
+        await this.client.destroy();
+      } catch (err) {
+        error('Error destroying Discord client: ' + String(err));
+        if (!transportError) transportError = err;
+      }
     }
+
+    if (transportError) throw transportError;
   }
 } 


### PR DESCRIPTION
## Summary

Ensure `DiscordMCPServer.stop()` always destroys the Discord client, even when MCP transport shutdown rejects.

## Why

The current method awaits `transport.stop()` before destroying Discord. If transport cleanup throws, execution skips `client.destroy()`, leaving the Discord WebSocket and heartbeat timers alive.

That can keep a stdio MCP process running after its client disconnects.

## Behavior

- Transport cleanup is attempted first.
- Discord cleanup always runs.
- The original cleanup error is logged and propagated.

## Verification

- Added a focused failure-path test that forces `transport.stop()` to reject and verifies `client.destroy()` still runs.
- TypeScript build passed.