### PR TITLE
fix: handle Discord client and shard error events

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,11 @@ const client = new Client({
     ]
 });
 
+// EventEmitter treats an unhandled 'error' event as fatal. Log Discord gateway
+// and shard errors so transient network failures do not terminate the server.
+client.on('error', (err) => error('Discord client error: ' + String(err)));
+client.on('shardError', (err) => error('Discord shard error: ' + String(err)));
+
 // Save token to client for login handler
 if (config.DISCORD_TOKEN) {
     client.token = config.DISCORD_TOKEN;


### PR DESCRIPTION
## Summary

Register handlers for Discord client and shard error events.

## Why

Node's `EventEmitter` treats an unhandled `error` event as fatal. A transient Discord gateway or WebSocket error can therefore terminate the MCP process even when the connection can recover.

The handlers log `error` and `shardError` events through the existing stderr logger. Login failures and tool-call errors keep their current behavior.

## Verification

TypeScript build passed.