### PR TITLE
fix: accept camelCase token configuration

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ const config = {
                 if (typeof configArg === 'string') {
                     try {
                         const parsedConfig = JSON.parse(configArg);
-                        return parsedConfig.DISCORD_TOKEN;
+                        return parsedConfig.DISCORD_TOKEN ?? parsedConfig.discordToken;
                     } catch (err) {
                         // If not valid JSON, try using the string directly
                         return configArg;


### PR DESCRIPTION
## Summary

Accept both `DISCORD_TOKEN` and `discordToken` when parsing JSON supplied through `--config`.

## Why

The existing uppercase form remains supported, while clients that serialize the repository's camelCase configuration schema can pass the same token without rewriting the key.

Environment-variable and plain-token behavior are unchanged.

## Verification

- TypeScript build passed.
- A stdio smoke test supplied `discordToken` through JSON configuration and reached the Discord login path.
- The process then completed a clean stdin-EOF shutdown with stdout empty.