### PR TITLE
fix(http): build an MCP server per session instead of sharing one

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -192,7 +192,6 @@ const config = {
 };
 
 const discord = createDiscordClient(config.DISCORD_TOKEN);
-const server = createMcpServer(discord);
 
 const app = express();
 app.use(express.json());
@@ -234,8 +233,12 @@ const mcpPostHandler = async (req: Request, res: Response) => {
                 }
             };
 
-            // Connect the transport to the MCP server before handling the request
-            await server.connect(transport);
+            // Connect the transport to a server instance of its own. The SDK's
+            // Protocol allows exactly one transport per server, so a shared
+            // instance would make every session after the first fail with
+            // "Already connected to a transport". The Discord client stays
+            // shared, so this still uses a single gateway connection.
+            await createMcpServer(discord).connect(transport);
 
             await transport.handleRequest(req, res, req.body);
             return;
@@ -339,7 +342,7 @@ if (config.TRANSPORT.toLowerCase() === 'http') {
 } else {
     // Stdio transport
     const transport = new StdioServerTransport();
-    await server.connect(transport);
+    await createMcpServer(discord).connect(transport);
     process.stderr.write('MCP Stdio Server started. Awaiting messages...\n');
 
 }


### PR DESCRIPTION
Fixes #41.

## Problem

`src/app.ts` built one module-level server and reused it for every session:

```ts
const discord = createDiscordClient(config.DISCORD_TOKEN);
const server = createMcpServer(discord);
```

`mcpPostHandler` then called `await server.connect(transport)` for each new
`StreamableHTTPServerTransport`. The SDK's `Protocol` accepts exactly one
transport per server instance, so the second `initialize` threw:

```
Error handling MCP request: Error: Already connected to a transport. Call close() before connecting to a new transport, or use a separate Protocol instance per connection.
```

The `catch` turned that into `500 {"error":{"code":-32000,"message":"Internal server error."}}`. It was permanent for the life of the process: `transport.onclose` removes the entry from `transports` but never releases the server, so ending the first session did not free the slot.

## Fix

Construct the server inside the initialize branch, which is what the SDK's `streamableHttp` example does. The Discord client stays module-level, so a process still opens a single gateway connection per token — the constraint that made sharing look necessary applies to the client, not to the `McpServer`.

The stdio branch builds its server the same way. It only ever has one connection, but there is no module-level instance left to reuse.

## Verification

Built the image from this branch and posted the same `initialize` body three times with no session header:

| | before | after |
|---|---|---|
| initialize #1 | `200` | `200` |
| initialize #2 | `500` | `200` |
| initialize #3 | `500` | `200` |

Each session then answered `tools/list` with all 24 tools, concurrently, and `Already connected to a transport` no longer appears in the logs.

`npm test` — 17 suites, 361 tests passing. `tsc --noEmit` clean.

## Note, not addressed here

`createMcpServer` does `(client as any).server = server.server`, so with per-session servers the shared client points at whichever session initialized most recently, and `logClientState` sends its `notifications/message` there. The existing `if (!client.server || !client.server.transport) return` guard keeps it from throwing after a session closes, so this is a log-routing wart rather than a fault. Happy to follow up separately if you would like log notifications fanned out per session.

Separately, `mcpPostHandler`/`mcpGetHandler` answer an unknown session id with `400`. The spec has clients start a new session on `404`, so a client whose session was dropped currently wedges instead of re-initializing. Also happy to send that as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
