### PR TITLE
feat!: embeds and attachments on read_messages, embeds on discord_send

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ Important notes:
 
 - `discord_login`: Login to Discord using the configured token
 - `discord_list_servers`: List all Discord servers the bot is a member of
-- `discord_send`: Send a message to a specified channel
+- `discord_send`: Send a message to a specified channel (optionally as a reply, optionally with up to 10 `embeds` — `message` may then be empty); returns the sent message ID and URL
 - `discord_get_server_info`: Get Discord server information
 
 ### Channel Management
@@ -295,6 +295,10 @@ Important notes:
 
 - `discord_search_messages`: Search messages in a server
 - `discord_read_messages`: Read channel messages (supports `before`, `after`, `around` params — accepts snowflake IDs or ISO 8601 dates like `"2025-03-01T00:00:00Z"`)
+  - each message carries its `url` (jump link) and `webhookId` (set when it was posted through a webhook)
+  - `embeds`: the full content of each embed (`title`, `description`, `url`, `color`, `author`, `fields`, `footer`, `image`, `thumbnail`, `timestamp`) — the `author` / `footer` objects have the same shape as the `discord_send` embed input
+  - `attachments`: `id`, `name`, `url`, `contentType`, `size`, `width`, `height` for each attachment
+  - **breaking**: `embeds` and `attachments` were bare counts in earlier versions — use `.length` for the count
 - `discord_edit_message`: Edit a bot-authored message
 - `discord_add_reaction`: Add a reaction to a message
 - `discord_add_multiple_reactions`: Add multiple reactions to a message

--- a/src/schemas.test.ts
+++ b/src/schemas.test.ts
@@ -74,6 +74,34 @@ describe('Discord Schemas Validation Tests', () => {
             const data = { channelId: 123, message: 'Hello' };
             expect(() => SendMessageSchema.parse(data)).toThrow();
         });
+
+        test('should accept optional embeds', () => {
+            const data = {
+                channelId: 'channel123',
+                message: '',
+                embeds: [{
+                    title: 'Issues created',
+                    description: '[#1 First issue](https://example.com/1)',
+                    url: 'https://example.com/1',
+                    color: 0x2ECC71,
+                    fields: [{ name: 'Status', value: 'To do', inline: true }],
+                    footer: { text: 'triage' },
+                    author: { name: 'bot', url: 'https://example.com' },
+                    timestamp: '2026-01-01T00:00:00.000Z'
+                }]
+            };
+            expect(SendMessageSchema.parse(data)).toEqual(data);
+        });
+
+        test('should reject an invalid embed url', () => {
+            const data = { channelId: 'channel123', message: 'x', embeds: [{ title: 'Bad', url: 'not a url' }] };
+            expect(() => SendMessageSchema.parse(data)).toThrow();
+        });
+
+        test('should reject more than 10 embeds', () => {
+            const embeds = Array.from({ length: 11 }, (_, i) => ({ title: `Embed ${i}` }));
+            expect(() => SendMessageSchema.parse({ channelId: 'channel123', message: 'x', embeds })).toThrow();
+        });
     });
 
     describe('GetForumChannelsSchema', () => {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -6,12 +6,35 @@ export const DiscordLoginSchema = z.object({
     description: "Login to Discord using a bot token. If no token is provided, the bot will attempt to use the token from the environment variable DISCORD_TOKEN."
 });
 
+export const EmbedFieldSchema = z.object({
+    name: z.string({ description: "Field title (max 256 characters)." }).max(256),
+    value: z.string({ description: "Field text (max 1024 characters)." }).max(1024),
+    inline: z.boolean({ description: "Display the field inline with the previous one." }).optional()
+});
+
+export const EmbedSchema = z.object({
+    title: z.string({ description: "Embed title (max 256 characters)." }).max(256).optional(),
+    description: z.string({ description: "Embed body, supports Discord markdown (max 4096 characters)." }).max(4096).optional(),
+    url: z.string({ description: "URL the title links to." }).url().optional(),
+    color: z.number({ description: "Left border colour as an integer (e.g. 0x2ECC71 = 3066993)." }).int().min(0).max(0xFFFFFF).optional(),
+    fields: z.array(EmbedFieldSchema, { description: "Up to 25 fields." }).max(25).optional(),
+    footer: z.object({ text: z.string({ description: "Footer text (max 2048 characters)." }).max(2048) }).optional(),
+    author: z.object({
+        name: z.string({ description: "Author name (max 256 characters)." }).max(256),
+        url: z.string({ description: "URL the author name links to." }).url().optional()
+    }).optional(),
+    timestamp: z.string({ description: "ISO 8601 timestamp shown in the footer." }).optional()
+}, {
+    description: "A Discord embed: title, description, url, color, fields, footer, author and timestamp."
+});
+
 export const SendMessageSchema = z.object({
     channelId: z.string({ description: "The ID of the channel to send the message to." }),
-    message: z.string({ description: "The content of the message to send." }),
-    replyToMessageId: z.string({ description: "The ID of the message to reply to, if any." }).optional()
+    message: z.string({ description: "The content of the message to send (may be empty when embeds are supplied)." }),
+    replyToMessageId: z.string({ description: "The ID of the message to reply to, if any." }).optional(),
+    embeds: z.array(EmbedSchema, { description: "Up to 10 embeds to attach to the message." }).max(10).optional()
 }, {
-    description: "Send a message to a specified channel, optionally as a reply to another message."
+    description: "Send a message to a specified channel, optionally as a reply to another message and/or with embeds."
 });
 
 export const GetForumChannelsSchema = z.object({

--- a/src/toolList.ts
+++ b/src/toolList.ts
@@ -52,13 +52,56 @@ export const toolList = [
   },
   {
     name: "discord_send",
-    description: "Sends a message to a specified Discord text channel. Optionally reply to another message by providing its message ID.",
+    description: "Sends a message to a specified Discord text channel. Optionally reply to another message by providing its message ID, and/or attach up to 10 embeds. Returns the sent message ID and URL.",
     inputSchema: {
       type: "object",
       properties: {
         channelId: { type: "string" },
-        message: { type: "string" },
-        replyToMessageId: { type: "string" }
+        message: { type: "string", description: "The content of the message to send (may be empty when embeds are supplied)." },
+        replyToMessageId: { type: "string", description: "The ID of the message to reply to, if any." },
+        embeds: {
+          type: "array",
+          maxItems: 10,
+          description: "Up to 10 embeds to attach to the message.",
+          items: {
+            type: "object",
+            description: "A Discord embed: title, description, url, color, fields, footer, author and timestamp.",
+            properties: {
+              title: { type: "string", maxLength: 256, description: "Embed title (max 256 characters)." },
+              description: { type: "string", maxLength: 4096, description: "Embed body, supports Discord markdown (max 4096 characters)." },
+              url: { type: "string", format: "uri", description: "URL the title links to." },
+              color: { type: "integer", minimum: 0, maximum: 16777215, description: "Left border colour as an integer (e.g. 0x2ECC71 = 3066993)." },
+              fields: {
+                type: "array",
+                maxItems: 25,
+                description: "Up to 25 fields.",
+                items: {
+                  type: "object",
+                  properties: {
+                    name: { type: "string", maxLength: 256, description: "Field title (max 256 characters)." },
+                    value: { type: "string", maxLength: 1024, description: "Field text (max 1024 characters)." },
+                    inline: { type: "boolean", description: "Display the field inline with the previous one." }
+                  },
+                  required: ["name", "value"]
+                }
+              },
+              footer: {
+                type: "object",
+                properties: { text: { type: "string", maxLength: 2048, description: "Footer text (max 2048 characters)." } },
+                required: ["text"]
+              },
+              author: {
+                type: "object",
+                properties: {
+                  name: { type: "string", maxLength: 256, description: "Author name (max 256 characters)." },
+                  url: { type: "string", format: "uri", description: "URL the author name links to." }
+                },
+                required: ["name"]
+              },
+              timestamp: { type: "string", description: "ISO 8601 timestamp shown in the footer." }
+            }
+          }
+        }
       },
       required: ["channelId", "message"]
     }
@@ -186,7 +229,7 @@ export const toolList = [
   },
   {
     name: "discord_read_messages",
-    description: "Retrieves messages from a Discord text channel. Supports date-based filtering via before/after/around params (accepts snowflake IDs or ISO 8601 dates).",
+    description: "Retrieves messages from a Discord text channel. Supports date-based filtering via before/after/around params (accepts snowflake IDs or ISO 8601 dates). Each message includes its jump URL, webhook ID (when posted through a webhook), the full embed content (author/footer/image/thumbnail/fields) and the attachments (name, url, contentType, size, width, height).",
     inputSchema: {
       type: "object",
       properties: {

--- a/src/tools/channel.test.ts
+++ b/src/tools/channel.test.ts
@@ -56,7 +56,7 @@ const mockMessage = {
     bot: false,
   },
   createdAt: new Date('2023-09-01T12:00:00Z'),
-  attachments: { size: 0 },
+  attachments: { size: 0, map: () => [] },
   embeds: [],
   reference: null,
 };
@@ -682,6 +682,98 @@ describe('Channel Handlers', () => {
       expect(result).toEqual({
         content: [{ type: "text", text: 'No messages found in channel' }]
       });
+    });
+
+    it('should return empty arrays and null webhook id for a plain message', async () => {
+      const plainMessage = {
+        ...mockMessage,
+        url: 'https://discord.com/channels/guildId/textChannelId/messageId',
+        webhookId: null,
+        reactions: { cache: { map: (fn: (value: any) => any) => [].map(fn) } }
+      };
+      const messagesCollection = new Map([[plainMessage.id, plainMessage]]);
+      Object.defineProperty(messagesCollection, 'map', {
+        value: (fn: (value: any) => any) => Array.from(messagesCollection.values()).map(fn),
+        writable: true,
+        configurable: true
+      });
+
+      mockContext.client.isReady.mockReturnValue(true);
+      mockContext.client.channels.fetch.mockResolvedValue(mockTextChannel);
+      mockTextChannel.messages.fetch.mockResolvedValue(messagesCollection);
+
+      const result = await readMessagesHandler({ channelId: 'textChannelId', limit: 10 }, mockContext);
+
+      const [message] = JSON.parse((result.content[0] as any).text).messages;
+      expect(message.webhookId).toBeNull();
+      expect(message.attachments).toEqual([]);
+      expect(message.embeds).toEqual([]);
+      expect(message.replyTo).toBeNull();
+    });
+
+    it('should return the message url, webhook id, embed content and attachments', async () => {
+      const richMessage = {
+        id: 'messageId',
+        content: '',
+        author: { id: 'webhookUserId', username: 'Suggestions', bot: true },
+        createdAt: new Date('2023-09-01T12:00:00Z'),
+        url: 'https://discord.com/channels/guildId/textChannelId/messageId',
+        webhookId: 'webhookId',
+        attachments: {
+          map: (fn: (value: any) => any) => [{
+            id: 'attachmentId', name: 'screenshot.png', url: 'https://cdn.example/screenshot.png',
+            contentType: 'image/png', size: 1234, width: 800, height: 600
+          }].map(fn)
+        },
+        embeds: [{
+          title: 'Suggestion',
+          description: 'Add a new puzzle\n\n**Player:** Steve',
+          url: null,
+          color: 0x2ECC71,
+          author: { name: 'Steve', url: null, iconURL: null },
+          fields: [{ name: 'Server', value: 'play', inline: true }],
+          footer: { text: 'LEPSU', iconURL: null },
+          image: { url: 'https://cdn.example/screenshot.png' },
+          thumbnail: null,
+          timestamp: null
+        }],
+        reference: null,
+        reactions: { cache: { map: (fn: (value: any) => any) => [].map(fn) } }
+      };
+      const messagesCollection = new Map([[richMessage.id, richMessage]]);
+      Object.defineProperty(messagesCollection, 'map', {
+        value: (fn: (value: any) => any) => Array.from(messagesCollection.values()).map(fn),
+        writable: true,
+        configurable: true
+      });
+
+      mockContext.client.isReady.mockReturnValue(true);
+      mockContext.client.channels.fetch.mockResolvedValue(mockTextChannel);
+      mockTextChannel.messages.fetch.mockResolvedValue(messagesCollection);
+
+      const result = await readMessagesHandler({ channelId: 'textChannelId', limit: 10 }, mockContext);
+
+      const payload = JSON.parse((result.content[0] as any).text);
+      expect(payload.messageCount).toBe(1);
+      const [message] = payload.messages;
+      expect(message.url).toBe('https://discord.com/channels/guildId/textChannelId/messageId');
+      expect(message.webhookId).toBe('webhookId');
+      expect(message.attachments).toEqual([{
+        id: 'attachmentId', name: 'screenshot.png', url: 'https://cdn.example/screenshot.png',
+        contentType: 'image/png', size: 1234, width: 800, height: 600
+      }]);
+      expect(message.embeds).toEqual([{
+        title: 'Suggestion',
+        description: 'Add a new puzzle\n\n**Player:** Steve',
+        url: null,
+        color: 0x2ECC71,
+        author: { name: 'Steve', url: null, iconURL: null },
+        fields: [{ name: 'Server', value: 'play', inline: true }],
+        footer: { text: 'LEPSU', iconURL: null },
+        image: 'https://cdn.example/screenshot.png',
+        thumbnail: null,
+        timestamp: null
+      }]);
     });
 
     it('should handle Discord errors', async () => {

--- a/src/tools/channel.ts
+++ b/src/tools/channel.ts
@@ -343,8 +343,32 @@ export async function readMessagesHandler(
         bot: msg.author.bot
       },
       timestamp: msg.createdAt,
-      attachments: msg.attachments.size,
-      embeds: msg.embeds.length,
+      url: msg.url,
+      // Set when the message was posted through a webhook (its author is then the webhook user)
+      webhookId: msg.webhookId,
+      attachments: msg.attachments.map(a => ({
+        id: a.id,
+        name: a.name,
+        url: a.url,
+        contentType: a.contentType ?? null,
+        size: a.size,
+        width: a.width ?? null,
+        height: a.height ?? null
+      })),
+      // Full embed content (webhook/bot messages often carry their whole payload here).
+      // author/footer mirror the discord_send embed shape so an embed can be read and re-sent as-is.
+      embeds: msg.embeds.map(e => ({
+        title: e.title ?? null,
+        description: e.description ?? null,
+        url: e.url ?? null,
+        color: e.color ?? null,
+        author: e.author ? { name: e.author.name, url: e.author.url ?? null, iconURL: e.author.iconURL ?? null } : null,
+        fields: e.fields.map(f => ({ name: f.name, value: f.value, inline: f.inline ?? false })),
+        footer: e.footer ? { text: e.footer.text, iconURL: e.footer.iconURL ?? null } : null,
+        image: e.image?.url ?? null,
+        thumbnail: e.thumbnail?.url ?? null,
+        timestamp: e.timestamp ?? null
+      })),
       replyTo: msg.reference ? msg.reference.messageId : null,
       // Expose reactions populated by REST fetch (no Gateway intent required).
       // Each entry includes the unicode/custom emoji name+id, total count, and

--- a/src/tools/channel_comprehensive.test.ts
+++ b/src/tools/channel_comprehensive.test.ts
@@ -59,7 +59,7 @@ const createMockMessage = (id: string, content: string, authorId: string, author
     bot: false,
   },
   reference: null,
-  attachments: { size: 0 },
+  attachments: { size: 0, map: () => [] },
   embeds: [],
 });
 

--- a/src/tools/send-message.test.ts
+++ b/src/tools/send-message.test.ts
@@ -7,6 +7,7 @@ import { Client, Channel, TextBasedChannel } from 'discord.js';
 const mockMessage = {
   id: 'message123',
   content: 'Test message',
+  url: 'https://discord.com/channels/guild123/channel123/message123',
 };
 
 const mockTextChannel: any = {
@@ -102,8 +103,62 @@ describe('sendMessageHandler', () => {
     // Assert
     expect(mockTextChannel.send).toHaveBeenCalledWith({ content: 'Hello World' });
     expect(result).toEqual({
-      content: [{ type: "text", text: "Message successfully sent to channel ID: channel123" }]
+      content: [{ type: "text", text: "Message successfully sent to channel ID: channel123 (message ID: message123, URL: https://discord.com/channels/guild123/channel123/message123)" }]
     });
+  });
+
+  it('should send message with embeds when embeds are provided', async () => {
+    // Arrange
+    mockClient.isReady.mockReturnValue(true);
+    mockClient.channels.fetch.mockResolvedValue(mockTextChannel);
+    const embeds = [{
+      title: 'Issues created',
+      description: '[#1 First issue](https://example.com/1)',
+      color: 0x2ECC71,
+      fields: [{ name: 'Status', value: 'To do', inline: true }],
+      footer: { text: 'triage' }
+    }];
+
+    // Act
+    const result = await sendMessageHandler(
+      { channelId: 'channel123', message: 'Issues created', embeds },
+      { client: mockClient }
+    );
+
+    // Assert
+    expect(mockTextChannel.send).toHaveBeenCalledWith({ content: 'Issues created', embeds });
+    expect(result).toEqual({
+      content: [{ type: "text", text: "Message successfully sent to channel ID: channel123 (message ID: message123, URL: https://discord.com/channels/guild123/channel123/message123)" }]
+    });
+  });
+
+  it('should send a reply with embeds', async () => {
+    mockClient.isReady.mockReturnValue(true);
+    mockClient.channels.fetch.mockResolvedValue(mockTextChannel);
+    const embeds = [{ title: 'Tracked', description: 'See #42' }];
+
+    await sendMessageHandler(
+      { channelId: 'channel123', message: 'Thanks!', replyToMessageId: 'message123', embeds },
+      { client: mockClient }
+    );
+
+    expect(mockTextChannel.send).toHaveBeenCalledWith({
+      content: 'Thanks!',
+      reply: { messageReference: 'message123' },
+      embeds
+    });
+  });
+
+  it('should not set embeds when an empty array is provided', async () => {
+    mockClient.isReady.mockReturnValue(true);
+    mockClient.channels.fetch.mockResolvedValue(mockTextChannel);
+
+    await sendMessageHandler(
+      { channelId: 'channel123', message: 'Hello World', embeds: [] },
+      { client: mockClient }
+    );
+
+    expect(mockTextChannel.send).toHaveBeenCalledWith({ content: 'Hello World' });
   });
 
   it('should send message as reply when replyToMessageId is provided and message exists', async () => {
@@ -127,7 +182,7 @@ describe('sendMessageHandler', () => {
       reply: { messageReference: 'message123' }
     });
     expect(result).toEqual({
-      content: [{ type: "text", text: "Message successfully sent to channel ID: channel123 as a reply to message ID: message123" }]
+      content: [{ type: "text", text: "Message successfully sent to channel ID: channel123 as a reply to message ID: message123 (message ID: message123, URL: https://discord.com/channels/guild123/channel123/message123)" }]
     });
   });
 

--- a/src/tools/send-message.ts
+++ b/src/tools/send-message.ts
@@ -3,7 +3,7 @@ import { ToolHandler } from './types.js';
 import { handleDiscordError } from "../errorHandler.js";
 
 export const sendMessageHandler: ToolHandler = async (args, { client }) => {
-  const { channelId, message, replyToMessageId } = SendMessageSchema.parse(args);
+  const { channelId, message, replyToMessageId, embeds } = SendMessageSchema.parse(args);
   
   try {
     if (!client.isReady()) {
@@ -50,11 +50,18 @@ export const sendMessageHandler: ToolHandler = async (args, { client }) => {
       // Set the message content
       messageOptions.content = message;
       
-      await channel.send(messageOptions);
+      // Attach embeds (plain APIEmbed objects are accepted by discord.js as-is)
+      if (embeds && embeds.length > 0) {
+        messageOptions.embeds = embeds;
+      }
+
+      const sent = await channel.send(messageOptions);
       
-      const responseText = replyToMessageId 
+      const baseText = replyToMessageId
         ? `Message successfully sent to channel ID: ${channelId} as a reply to message ID: ${replyToMessageId}`
         : `Message successfully sent to channel ID: ${channelId}`;
+      // Expose the sent message so callers can link to it or edit it later
+      const responseText = `${baseText} (message ID: ${sent.id}, URL: ${sent.url})`;
       
       return {
         content: [{ type: "text", text: responseText }]


### PR DESCRIPTION
feat!: embeds and attachments on read_messages, embeds on discord_send

## What

- **`discord_read_messages`** — each message now carries:
  - `url`: the jump link (`https://discord.com/channels/<guild>/<channel>/<message>`);
  - `webhookId`: set when the message was posted through a webhook (its `author` is then the webhook user);
  - `embeds`: the full content of each embed — `title`, `description`, `url`, `color`, `author` (`{ name, url, iconURL }`), `fields`, `footer` (`{ text, iconURL }`), `image` / `thumbnail` URLs, `timestamp` — instead of a bare count. The `author` / `footer` objects mirror the `discord_send` embed input, so an embed can be read and re-sent as-is;
  - `attachments`: `id`, `name`, `url`, `contentType`, `size`, `width`, `height` for each attachment instead of a bare count.
- **`discord_send`** — new optional `embeds` parameter (up to 10 embeds, validated by zod: title, description, url, color, fields, footer, author, timestamp; the JSON schema in `toolList.ts` mirrors it, descriptions included). `message` may be empty when embeds are supplied. The response now includes the sent message **ID and URL** so a caller can link to it or `discord_edit_message` it later.

## Why

Bots and webhooks (bug-report / suggestion feeds, CI notifications, …) put their whole payload in embeds: with counts only, an MCP client cannot read those messages at all, nor open the screenshots attached to a report. Sending embeds lets an agent post structured summaries (e.g. a list of created issues) instead of a wall of markdown. Returning the sent message ID/URL closes the loop with `discord_edit_message`.

## Breaking change — your call on the version

`attachments` and `embeds` in the read output change from **numbers to arrays** (`.length` still gives the former count; the rest of the message shape is unchanged). I went for the array rather than an additive `attachmentList` / `embedList` next to the counts, because a bare count is of little use to an LLM client and the dual shape would stay forever. If you prefer the additive variant to keep 1.x compatible, say so and I'll rework it. The commit carries the `!` marker and a `BREAKING CHANGE:` footer; the README notes it.

## Notes

- Plain `APIEmbed` objects are passed to `channel.send()` as-is (discord.js accepts them without `EmbedBuilder`); a rejected embed (50035) surfaces through the existing `handleDiscordError` path.
- The 6000-character total per message is left to Discord's own validation (error surfaced verbatim).
- No new tool, so no registration change in `server.ts` / `app.ts`; no version bump (left to you).

## Checks

- `npm test` — 394 tests pass (8 new: embed send, reply + embeds, empty `embeds` array, schema accepts embeds / rejects invalid url / rejects > 10, rich read output, plain-message read output).
- `npx tsc --noEmit` / `npm run build` — clean.
- README *Tools Documentation* updated for both tools.
